### PR TITLE
:bug: Clean up go module names and set consistent Go version

### DIFF
--- a/examples/cluster-api/go.mod
+++ b/examples/cluster-api/go.mod
@@ -1,12 +1,11 @@
-module sigs.k8s.io/multicluster-runtime/examples/fleet
+module sigs.k8s.io/multicluster-runtime/examples/cluster-api
 
-go 1.23.4
+go 1.23.0
 
-toolchain go1.24.0
-
-replace sigs.k8s.io/multicluster-runtime => ../..
-
-replace sigs.k8s.io/multicluster-runtime/providers/cluster-api => ../../providers/cluster-api
+replace (
+	sigs.k8s.io/multicluster-runtime => ../..
+	sigs.k8s.io/multicluster-runtime/providers/cluster-api => ../../providers/cluster-api
+)
 
 require (
 	golang.org/x/sync v0.10.0

--- a/examples/kind/go.mod
+++ b/examples/kind/go.mod
@@ -1,10 +1,11 @@
-module sigs.k8s.io/multicluster-runtime/examples/fleet
+module sigs.k8s.io/multicluster-runtime/examples/kind
 
 go 1.23.0
 
-replace sigs.k8s.io/multicluster-runtime => ../..
-
-replace sigs.k8s.io/multicluster-runtime/providers/kind => ../../providers/kind
+replace (
+	sigs.k8s.io/multicluster-runtime => ../..
+	sigs.k8s.io/multicluster-runtime/providers/kind => ../../providers/kind
+)
 
 require (
 	golang.org/x/sync v0.8.0

--- a/providers/cluster-api/go.mod
+++ b/providers/cluster-api/go.mod
@@ -1,10 +1,10 @@
-module sigs.k8s.io/multicluster-runtime/providers/clsuter-api
+module sigs.k8s.io/multicluster-runtime/providers/cluster-api
 
-go 1.23.4
+go 1.23.0
 
-replace sigs.k8s.io/multicluster-runtime => ../..
-
-replace sigs.k8s.io/multicluster-runtime/providers/cluster-api => ../../providers/cluster-api
+replace (
+	sigs.k8s.io/multicluster-runtime => ../..
+)
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/providers/kind/go.mod
+++ b/providers/kind/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/multicluster-runtime/providers/fleet
+module sigs.k8s.io/multicluster-runtime/providers/kind
 
 go 1.23.0
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

It looks the changes from #17 got accidentally reverted in #20, so this PR reinstates them and tries to clean up the various `go.mod` files a bit by removing the `toolchain` directive and pinning the minimum Go version to 1.23.0 in all of them.
