### PR TITLE
:book: Update README to clarify provider implementation concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ multicluster-runtime is a Go library to write Kubernetes controllers that reconc
 
 - **dynamic fleet orchestration**: So-called providers interact with multi-cluster solutions like Cluster API and dynamically start and stop reconciliation against clusters discovered through the provider.
 - **no fork, no go mod replace**: clean extension to [upstream controller-runtime](https://github.com/kubernetes-sigs/controller-runtime).
-- **universal**: kind, [cluster-api](https://github.com/kubernetes-sigs/cluster-api), [Gardener](https://gardener.cloud/) (tbd), kcp (WIP), BYO. Cluster providers make the controller-runtime multi-cluster aware.
+- **universal**: Any kind of multi-cluster solution could theoretically be supported (kind, [cluster-api](https://github.com/kubernetes-sigs/cluster-api), [Gardener](https://gardener.cloud/) (tbd), [kcp](https://kcp.io), BYO). Cluster providers make the controller-runtime multi-cluster aware.
 - **seamless**: add multi-cluster support without compromising on single-cluster. Run in either mode without code changes to the reconcilers.
 
 ## Patterns Possible with multicluster-runtime
@@ -45,6 +45,17 @@ Run reconcilers that listen to some cluster(s) and operate other clusters.
 4. multicluster-runtime is developed as if it was part of controller-runtime (quality standards, naming, style).
 5. multicluster-runtime could be a testbed for native controller-runtime functionality, eventually becoming superfluous.
 6. multicluster-runtime is provider agnostic, but may contain providers with its own go.mod files and dedicated OWNERS files.
+    * These providers should be understood as reference implementations and are generally limited to projects hosted by a Kubernetes SIG.
+    * "Production-ready" providers shall be hosted in their own respective repositories close to the project they support.
+
+## Provider Ecosystem
+
+> [!NOTE]
+> If you are developing a multicluster-runtime provider, please feel free to open a PR and add your implementation to this list!
+
+The following cluster provider implementations exist outside of this repository:
+
+- [kcp-dev/multicluster-provider](https://github.com/kcp-dev/multicluster-provider): Collection of multicluster-runtime providers to interact with [kcp](https://kcp.io)'s logical clusters.
 
 ## Code Sample
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

We've had some understandable confusion around the provider implementations in this repository (see e.g. #34), mostly because we clarified the providers' status as reference implementations in the KubeCon talk, but not really in the repository README file.

This PR attempts to clean up the language of the README a bit to limit provider implementations in this repository to be targeting SIG-hosted projects as reference implementations. Production-ready providers should be hosted in OOT repositories so they can provide their own lifecycle.

It also adds a list of known implementations so that we can foster an ecosystem and increase provider visibility.
