### PR TITLE
🐛 Small fix in kind example logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ go.work.sum
 
 # Go binaries of compiled tools
 hack/tools/bin
+
+# IDE files
+.vscode
+.idea

--- a/examples/kind/main.go
+++ b/examples/kind/main.go
@@ -72,7 +72,7 @@ func main() {
 					return reconcile.Result{}, err
 				}
 
-				log.Info("ConfigMap %s/%s in cluster %q", cm.Namespace, cm.Name, req.ClusterName)
+				log.Info("ConfigMap found", "namespace", cm.Namespace, "name", cm.Name, "cluster", req.ClusterName)
 
 				return ctrl.Result{}, nil
 			},


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
When testing the kind example provider, the current logging fails with an error. Fixed it to pass variables as kvp.

Looking at the exact error from the logs:
```2025-05-07T13:43:07+02:00  DPANIC  odd number of arguments passed as key-value pairs for logging  {"controller": "multicluster-configmaps", "controllerGroup": "", "controllerKind": "ConfigMap", "reconcileID": "d91ea729-5a92-4b0a-893c-53c43288edde", "cluster": "fleet-cluster1", "ignored key": "fleet-cluster1"}```


And further in the stack trace:
```

panic({0x102a657a0?, 0x1400004d1e0?})
    /Users/mk/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.darwin-arm64/src/runtime/panic.go:792 +0xf0
go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x2, 0x14000301930, {0x14000980640, 0x1, 0x1})
    /Users/mk/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:196 +0xcc
```