### PR TITLE
:bug: Engage cluster in single provider start process

### DIFF
--- a/providers/single/provider.go
+++ b/providers/single/provider.go
@@ -44,7 +44,10 @@ func New(name string, cl cluster.Cluster) *Provider {
 }
 
 // Run starts the provider and blocks.
-func (p *Provider) Run(ctx context.Context, _ mcmanager.Manager) error {
+func (p *Provider) Run(ctx context.Context, mgr mcmanager.Manager) error {
+	if err := mgr.Engage(ctx, p.name, p.cl); err != nil {
+		return err
+	}
 	<-ctx.Done()
 	return nil
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

It looks like we not only lost #17 but also #18 in #20. I didn't notice at the time, but this brings back the fix by @joshlreese and engages the `cluster.Cluster` in the `single` provider upon start.
