### PR TITLE
:sparkles: Add Scheme as option when configuring kubeconfig provider clusters

### DIFF
--- a/providers/kubeconfig/provider.go
+++ b/providers/kubeconfig/provider.go
@@ -29,6 +29,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -61,6 +63,9 @@ func New(opts Options) *Provider {
 	if opts.KubeconfigSecretKey == "" {
 		opts.KubeconfigSecretKey = DefaultKubeconfigSecretKey
 	}
+	if opts.Scheme == nil {
+		opts.Scheme = scheme.Scheme
+	}
 
 	return &Provider{
 		opts:     opts,
@@ -77,6 +82,8 @@ type Options struct {
 	KubeconfigSecretLabel string
 	// KubeconfigSecretKey is the key in the secret data that contains the kubeconfig.
 	KubeconfigSecretKey string
+	// Scheme is the scheme to use for the clusters.
+	Scheme *runtime.Scheme
 }
 
 type index struct {
@@ -254,7 +261,9 @@ func (p *Provider) createAndEngageCluster(ctx context.Context, clusterName strin
 
 	// Create a new cluster
 	log.Info("Creating new cluster from kubeconfig")
-	cl, err := cluster.New(restConfig)
+	cl, err := cluster.New(restConfig, func(o *cluster.Options) {
+		o.Scheme = p.opts.Scheme
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create cluster: %w", err)
 	}


### PR DESCRIPTION
Allows kubeconfig provider to set custom scheme for clusters