### PR TITLE
:seedling: Stop setting tags on example modules

### DIFF
--- a/hack/release-commit.sh
+++ b/hack/release-commit.sh
@@ -52,8 +52,8 @@ echo "Creating release tags ..."
 git tag -am "${TAG}" "${TAG}" ${GIT_TAG_OPTIONS}
 echo "Created tag ${TAG}."
 
-# create provider and example tags
-find "providers" "examples" -name go.mod | while read -r GOMOD; do
+# create provider tags
+find "providers" -name go.mod | while read -r GOMOD; do
     module=$(dirname "${GOMOD}")
     git tag -am "${module}/${TAG}" "${module}/${TAG}" ${GIT_TAG_OPTIONS}
     echo "Created tag ${module}/${TAG}."


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

I don't think it makes sense to set tags on the various `examples/` modules, since they are not meant for consumption as a go module from other repositories/modules. Therefore, to reduce the amount of tags on this repository, this PR stops setting tags on examples and only tags provider modules now.