### PR TITLE
🐛Make mcmanager.Options distinct from manager.Options

### DIFF
--- a/examples/cluster-api/main.go
+++ b/examples/cluster-api/main.go
@@ -82,9 +82,11 @@ func main() {
 	// Create a multi-cluster manager attached to the provider.
 	entryLog.Info("Setting up local manager")
 	mcMgr, err := mcmanager.New(cfg, provider, mcmanager.Options{
-		LeaderElection: false, // TODO(sttts): how to sync that with the upper manager?
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // only one can listen
+		Options: manager.Options{
+			LeaderElection: false, // TODO(sttts): how to sync that with the upper manager?
+			Metrics: metricsserver.Options{
+				BindAddress: "0", // only one can listen
+			},
 		},
 	})
 	if err != nil {

--- a/examples/cluster-inventory-api/main.go
+++ b/examples/cluster-inventory-api/main.go
@@ -33,6 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -92,9 +93,11 @@ func main() {
 	// Create a multi-cluster manager attached to the provider.
 	entryLog.Info("Setting up manager")
 	mcMgr, err := mcmanager.New(cfg, provider, mcmanager.Options{
-		LeaderElection: false,
-		Metrics: metricsserver.Options{
-			BindAddress: "0", // only one can listen
+		Options: manager.Options{
+			LeaderElection: false,
+			Metrics: metricsserver.Options{
+				BindAddress: "0", // only one can listen
+			},
 		},
 	})
 	if err != nil {

--- a/pkg/builder/forked_controller_test.go
+++ b/pkg/builder/forked_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
@@ -291,9 +292,11 @@ var _ = Describe("application", func() {
 
 			By("creating a controller manager")
 			m, err := mcmanager.New(cfg, nil, mcmanager.Options{
-				Controller: config.Controller{
-					GroupKindConcurrency: map[string]int{
-						"ReplicaSet.apps": maxConcurrentReconciles,
+				Options: manager.Options{
+					Controller: config.Controller{
+						GroupKindConcurrency: map[string]int{
+							"ReplicaSet.apps": maxConcurrentReconciles,
+						},
 					},
 				},
 			})
@@ -538,7 +541,11 @@ var _ = Describe("application", func() {
 			// use a cache that intercepts requests for fully typed objects to
 			// ensure we use the projected versions
 			var err error
-			mgr, err = mcmanager.New(cfg, nil, mcmanager.Options{NewCache: newNonTypedOnlyCache})
+			mgr, err = mcmanager.New(cfg, nil, mcmanager.Options{
+				Options: manager.Options{
+					NewCache: newNonTypedOnlyCache,
+				},
+			})
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -112,7 +112,9 @@ type Manager interface {
 }
 
 // Options are the arguments for creating a new Manager.
-type Options = manager.Options
+type Options struct {
+	manager.Options
+}
 
 // Runnable allows a component to be started.
 // It's very important that Start blocks until
@@ -135,7 +137,7 @@ type mcManager struct {
 // discover and manage clusters. With a provider set to nil, the manager will
 // behave like a regular controller-runtime manager.
 func New(config *rest.Config, provider multicluster.Provider, opts Options) (Manager, error) {
-	mgr, err := manager.New(config, opts)
+	mgr, err := manager.New(config, opts.Options)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/cluster-inventory-api/provider_test.go
+++ b/providers/cluster-inventory-api/provider_test.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
@@ -109,8 +110,10 @@ var _ = Describe("Provider Cluster Inventory API", Ordered, func() {
 		By("Setting up the cluster-aware manager, with the provider to lookup clusters", func() {
 			var err error
 			mgr, err = mcmanager.New(cfgHub, provider, mcmanager.Options{
-				Controller: config.Controller{
-					SkipNameValidation: ptr.To(true),
+				Options: manager.Options{
+					Controller: config.Controller{
+						SkipNameValidation: ptr.To(true),
+					},
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/providers/kubeconfig/provider_test.go
+++ b/providers/kubeconfig/provider_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -120,8 +121,10 @@ var _ = Describe("Provider Namespace", Ordered, func() {
 		By("Setting up the cluster-aware manager, with the provider to lookup clusters", func() {
 			var err error
 			mgr, err = mcmanager.New(localCfg, provider, mcmanager.Options{
-				Metrics: metricsserver.Options{
-					BindAddress: "0",
+				Options: manager.Options{
+					Metrics: metricsserver.Options{
+						BindAddress: "0",
+					},
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/providers/multi/provider_test.go
+++ b/providers/multi/provider_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
@@ -89,7 +88,7 @@ var _ = Describe("Provider Multi", Ordered, func() {
 			provider = New(Options{})
 
 			var err error
-			mgr, err = mcmanager.New(localCfg, provider, manager.Options{})
+			mgr, err = mcmanager.New(localCfg, provider, mcmanager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			provider.SetManager(mgr)


### PR DESCRIPTION
Various providers in this repo already use `manager.Options` instead of `mcmanger.Options` as they are the same type.

This PR changes `mcmanager.Options` to be a distinct type, embedding `manager.Options`.

I am unsure if it was intended that `mcmanger.Options` is just an alias for `manager.Options` - every other type alias I've found specifies a generic type.