### PR TITLE
✨ Add TypedEnqueueRequestsFromMapFuncWithClusterPreservation function

### DIFF
--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -34,3 +34,10 @@ func EnqueueRequestsFromMapFunc(fn handler.MapFunc) EventHandlerFunc {
 func TypedEnqueueRequestsFromMapFunc[object client.Object, request mcreconcile.ClusterAware[request]](fn handler.TypedMapFunc[object, request]) TypedEventHandlerFunc[object, request] {
 	return TypedInjectCluster[object, request](handler.TypedEnqueueRequestsFromMapFunc[object, request](fn))
 }
+
+// TypedEnqueueRequestsFromMapFuncWithClusterPreservation wraps handler.TypedEnqueueRequestsFromMapFunc
+// to work with mcreconcile.Request while preserving the ClusterName field set in the requests.
+// This avoids cluster injection and depends on the mapFunc to set the correct ClusterName in the request.
+func TypedEnqueueRequestsFromMapFuncWithClusterPreservation[object client.Object, request mcreconcile.ClusterAware[request]](fn handler.TypedMapFunc[object, request]) handler.TypedEventHandler[object, request] {
+	return handler.TypedEnqueueRequestsFromMapFunc[object, request](fn)
+}


### PR DESCRIPTION
I'm writing a controller with multicluster-runtime where objects on the local cluster are replicated to provider clusters. Instead of reconciling the local cluster object and replicating to each provider cluster within one reconciliation loop, whenever the local object is reconciled, the only work is to enqueue objects directly for provider clusters. This keeps the reconciliations fairly flat and fast. The provider object reconciliations then handle all the replication logic.

To that end, I tried using the `mchandler.EnqueueRequestsFromMapFunc` where I can create the `[]mcreconcile.Request`'s to be enqueued, but since it uses the `Lift` function under the covers, any cluster name I set in the returned `[]mcreconcile.Request`'s are overwritten before being added to the queue. It's a small code change to fix this but can be quite confusing if you haven't looked into the implementation of multicluster-runtime. I found it quite useful and thought it might be useful upstream as well!