### PR TITLE
🐛 Fix single provider package name

### DIFF
--- a/providers/single/provider.go
+++ b/providers/single/provider.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package namespace
+package single
 
 import (
 	"context"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

¯\\_(ツ)_/¯ 

```
"sigs.k8s.io/multicluster-runtime/providers/single" imported as namespace and not used
```