### PR TITLE
✨ Multi cluster controller sharding 

### DIFF
--- a/docs/designs/coordination.md
+++ b/docs/designs/coordination.md
@@ -1,0 +1,81 @@
+# Coordination and Sharding (Experimental)
+
+This document explains how multicluster-runtime coordinates per-cluster lifecycle, with a focus on the sharding coordinator that uses rendezvous hashing and Kubernetes Leases for fencing. The surface described here is **experimental** and may change without notice.
+
+## Goals
+
+- Single-writer semantics per remote cluster while allowing many controller instances to run.
+- Deterministic, balanced ownership decisions that react quickly to peer loss.
+- Clear separation between cluster discovery (providers) and ownership/fencing (coordinator).
+
+## Non-goals
+
+- Intra-cluster sharding (per-object) is out of scope.
+- Cross-process distributed transactions; fencing is best-effort via Leases.
+
+## Coordinator responsibilities
+
+The coordinator sits between the multicluster provider and the multicluster-aware runnables:
+
+- Track available clusters (via `Engage` from the provider).
+- Decide whether the local process should own a cluster.
+- Fence ownership so only one process is active per cluster at a time.
+- Start/stop the registered runnables for each cluster according to ownership.
+
+In the current codebase, this is exposed as a pluggable `Coordinator` interface. The default coordinator engages every cluster (legacy behavior); the sharded coordinator lives in `pkg/manager/coordinator/sharded` and is wired via `WithCoordinator(sharded.New(...))`.
+
+## Sharding coordinator design
+
+The sharding coordinator combines three building blocks:
+
+1. **Peer registry (`pkg/manager/coordinator/sharded/peers`)**  
+   - Each process writes/renews a peer Lease (`<peerPrefix>-<id>`, default `mcr-peer-<hostname>`) in `FenceNS` (default `kube-system`).  
+   - Lists peer Leases with the matching prefix to maintain a live snapshot (ID, weight).  
+   - Weight hints relative capacity (default 1).
+
+2. **Sharder (`pkg/manager/coordinator/sharded/sharder`)**  
+   - Default is HRW (rendezvous) hashing: given `(clusterID, peers[], self)` pick the peer with the highest score; weighted by peer weight.  
+   - Deterministic across peers for the same inputs.
+
+3. **Fencing (`pkg/manager/coordinator/sharded/leaseguard.go`)**  
+   - Per-cluster (default) or global Lease (`<fencePrefix>-<cluster>` with sanitization; default `mcr-shard-<cluster>`).  
+   - `HolderIdentity` is the peer ID; LeaseDuration (default 20s) renewed on each tick; Renew cadence (default 10s).  
+   - Throttles failed acquisition attempts to reduce API churn.
+
+### Lifecycle
+
+1. **Engage cluster**: When a provider discovers a cluster, it calls `Engage(ctx, name, cluster)`. The coordinator records the engagement (preserving any existing fence if re-engaging).
+2. **Decision loop**: On start and every `Probe` interval (default 5s):
+   - Refresh peer snapshot (peer registry runs in the background).
+   - Run HRW to decide if `self` should own each engaged cluster.
+   - If not the owner: cancel the engagement context and stop renewing the fence (Lease will expire).
+   - If owner: try to acquire/renew the fence Lease. If acquisition fails, wait for the next tick/backoff.
+   - After a successful fence acquisition, engage all registered multicluster runnables for that cluster.
+3. **Disengage/failover**:
+   - If the process stops renewing (crash or ctx cancel), the fence expires after `LeaseDuration` and another peer can take over on the next tick.
+   - Ownership changes when the peer set or weights change; HRW reassigns and fencing enforces single-writer.
+
+### Configuration (defaults from sharded.New)
+
+- `FenceNS`: namespace for fences and peer Leases (`kube-system`).
+- `FencePrefix`: base fence Lease name (`mcr-shard`).
+- `PerClusterLease`: true -> one fence per cluster (recommended); false -> one global fence.
+- `LeaseDuration`: 20s; `LeaseRenew`: 10s; `FenceThrottle`: 750ms.
+- `PeerPrefix`: peer Lease prefix (`mcr-peer`); `PeerWeight`: 1.
+- `Probe`: 5s; `Rehash`: 15s (reserved, not used by HRW today).
+
+`WithMultiCluster` defaults to the basic coordinator (engage all clusters). To enable sharding, supply `WithCoordinator(sharded.New(...))` with the desired options.
+
+### Scalability notes
+
+- Overhead is proportional to clusters: ~1 peer Lease per process, ~1 fence Lease per active cluster.
+- With 1,000 clusters and a 10s renew cadence, expect on the order of 100 write ops/sec across all owners. Increase `LeaseDuration`/`LeaseRenew` to reduce churn (at the cost of slower failover), or disable per-cluster fencing to avoid per-cluster Leases (at the cost of weaker isolation).
+
+### Failure handling
+
+- Lease expirations drive failover; no explicit release is required.
+- Throttling prevents tight retry loops when a fence is contested or the API is temporarily unavailable.
+
+## Future work
+
+- Revisit defaults to allow opt-in sharding with explicit config (namespace/prefix) or leave basic coordinator as the default.

--- a/examples/sharded-namespace/Dockerfile
+++ b/examples/sharded-namespace/Dockerfile
@@ -1,0 +1,21 @@
+# examples/sharded-namespace/Dockerfile
+# Multi-stage to keep image slim
+FROM golang:1.24 as build
+
+WORKDIR /src
+# Copy go.mod/sum from repo root so deps resolve; adjust paths if needed.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the whole repo to compile the example against local packages
+COPY . .
+
+# Build the example
+WORKDIR /src/examples/sharded-namespace
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/sharded-example main.go
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=build /out/sharded-example /sharded-example
+USER 65532:65532
+ENTRYPOINT ["/sharded-example"]

--- a/examples/sharded-namespace/README.md
+++ b/examples/sharded-namespace/README.md
@@ -1,0 +1,141 @@
+# Sharded Namespace Example
+
+This demo runs two replicas of a multicluster manager that **splits ownership** of downstream "clusters" discovered by the *namespace provider* (each Kubernetes Namespace == one cluster). Synchronization is decided by HRW hashing across peers, then serialized with per-cluster fencing Leases so exactly one peer reconciles a given cluster at a time.
+
+**Key Components:**
+- **Peer membership (presence)**: `coordination.k8s.io/Lease` with prefix `mcr-peer-*`
+- **Per-cluster fencing (synchronization)**: `coordination.k8s.io/Lease` with prefix `mcr-shard-<namespace>`
+
+Controllers attach per-cluster watches when synchronization starts, and cleanly detach & re-attach when it transfers.
+
+## Build the image
+
+From repo root:
+
+```bash
+docker build -t mcr-namespace:dev -f examples/sharded-namespace/Dockerfile .
+```
+
+If using KinD:
+```bash
+kind create cluster --name mcr-demo
+kind load docker-image mcr-namespace:dev --name mcr-demo
+```
+
+## Deploy
+
+```bash
+kubectl apply -k examples/sharded-namespace/manifests
+```
+
+## Observe
+
+Tail logs from pods:
+
+```bash
+kubectl -n mcr-demo get pods
+kubectl -n mcr-demo logs statefulset/sharded-namespace -f
+```
+
+You should see lines like:
+```bash
+"synchronization start    {"cluster": "zoo", "peer": "sharded-namespace-0"}"
+"synchronization start    {"cluster": "jungle", "peer": "sharded-namespace-1"}"
+
+Reconciling ConfigMap    {"controller": "multicluster-configmaps", "controllerGroup": "", "controllerKind": "ConfigMap", "reconcileID": "4f1116b3-b5 │
+│ 4e-4e6a-b84f-670ca5cfc9ce", "cluster": "zoo", "ns": "default", "name": "elephant"}  
+
+Reconciling ConfigMap    {"controller": "multicluster-configmaps", "controllerGroup": "", "controllerKind": "ConfigMap", "reconcileID": "688b8467-f5 │
+│ d3-491b-989e-87bc8aad780e", "cluster": "jungle", "ns": "default", "name": "monkey"} 
+```
+
+Check Leases:
+```bash
+# Peer membership (one per pod)
+kubectl -n kube-system get lease | grep '^mcr-peer-'
+
+# Per-cluster fencing (one per namespace/"cluster")
+kubectl -n kube-system get lease | grep '^mcr-shard-'
+```
+
+Who owns a given cluster?
+```bash
+C=zoo
+kubectl -n kube-system get lease mcr-shard-$C \
+  -o custom-columns=HOLDER:.spec.holderIdentity,RENEW:.spec.renewTime
+```
+
+
+## Test Synchronization
+
+Scale down to 1 replica and watch synchronization consolidate:
+```bash
+# Scale down
+kubectl -n mcr-demo scale statefulset/sharded-namespace --replicas=1
+
+
+# Watch leases lose their holders as pods terminate
+kubectl -n kube-system get lease -o custom-columns=NAME:.metadata.name,HOLDER:.spec.holderIdentity | grep "^mcr-shard-"
+
+# Wait for all clusters to be owned by the single remaining pod (~30s)
+kubectl -n kube-system wait --for=jsonpath='{.spec.holderIdentity}'=sharded-namespace-0 \
+ lease/mcr-shard-zoo lease/mcr-shard-jungle lease/mcr-shard-island --timeout=60s
+
+```
+Create/patch a ConfigMap and confirm the single owner reconciles it:
+```bash
+# Pick a cluster and create a test ConfigMap
+C=island
+kubectl -n "$C" create cm test-$(date +%s) --from-literal=ts=$(date +%s) --dry-run=client -oyaml | kubectl apply -f -
+
+# Verify only pod-q reconciles it (since it owns everything now)
+kubectl -n mcr-demo logs pod/sharded-namespace-0 --since=100s | grep "Reconciling ConfigMap.*$C"
+```
+
+Scale up to 3 replicas and watch synchronization rebalance:
+```bash
+# Scale up
+kubectl -n mcr-demo scale statefulset/sharded-namespace --replicas=3
+# Watch leases regain holders as pods start
+kubectl -n kube-system get lease -o custom-columns=NAME:.metadata.name,HOLDER:.spec.holderIdentity | grep "^mcr-shard-"
+
+# Create a cm in the default ns which belongs to sharded-namespace-2
+C=default
+kubectl -n "$C" create cm test-$(date +%s) --from-literal=ts=$(date +%s) --dry-run=client -oyaml | kubectl apply -f -
+# Verify only pod-2 reconciles it (since it owns the default ns now)
+kubectl -n mcr-demo logs pod/sharded-namespace-2 --since=100s | grep "Reconciling ConfigMap.*$C"
+```
+
+## Tuning
+In your example app (e.g., examples/sharded-namespace/main.go), configure fencing and timings:
+
+```go
+mgr, err := mcmanager.New(cfg, provider, manager.Options{},
+  // Per-cluster fencing Leases live here as mcr-shard-<namespace>
+  mcmanager.WithCoordinator(
+    sharded.New(kubeClient, logr.Discard(),
+      sharded.WithShardLease("kube-system", "mcr-shard"),
+      sharded.WithPerClusterLease(true), // enabled by default
+
+      // Optional: tune fencing timings (duration, renew, throttle):
+      // sharded.WithLeaseTimings(30*time.Second, 10*time.Second, 750*time.Millisecond),
+
+      // Optional: peer weight for HRW:
+      // sharded.WithPeerWeight(1),
+    ),
+  ),
+)
+if err != nil {
+  // handle error
+}
+```
+
+The peer registry uses mcr-peer-* automatically and derives the peer ID from the pod hostname (StatefulSet ordinal).
+
+## Cleanup
+
+```bash
+kubectl delete -k examples/sharded-namespace/manifests
+kind delete cluster --name mcr-demo
+
+```

--- a/examples/sharded-namespace/main.go
+++ b/examples/sharded-namespace/main.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// examples/sharded-namespace/main.go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sync/errgroup"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+	"sigs.k8s.io/multicluster-runtime/providers/namespace"
+)
+
+func main() {
+	klog.Background() // ensure klog initialized
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	log := ctrl.Log.WithName("sharded-example")
+
+	ctx := ctrl.SetupSignalHandler()
+
+	if err := run(ctx); err != nil {
+		log.Error(err, "exiting")
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	// use in-cluster config; fall back to default loading rules for local runs
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("get kubeconfig: %w", err)
+	}
+
+	// Provider: treats namespaces in the host cluster as “downstream clusters”.
+	host, err := cluster.New(cfg)
+	if err != nil {
+		return fmt.Errorf("create host cluster: %w", err)
+	}
+	provider := namespace.New(host)
+
+	// Direct client for coordinator (uses host scheme).
+	kubeClient, err := client.New(cfg, client.Options{Scheme: host.GetScheme()})
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+
+	// Multicluster manager (no peer ID passed; pod hostname becomes peer ID).
+	// Configure sharding:
+	// - fencing prefix: "mcr-shard" (per-cluster Lease names become mcr-shard-<cluster>)
+	// - peer membership still uses "mcr-peer" internally (set in WithMultiCluster)
+	// Peer ID defaults to os.Hostname().
+	mgr, err := mcmanager.New(cfg, provider, manager.Options{},
+		mcmanager.WithCoordinator(
+			sharded.New(kubeClient, ctrl.Log.WithName("sharded-coordinator"),
+				sharded.WithShardLease("kube-system", "mcr-shard"),
+				sharded.WithPerClusterLease(true),
+			),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("create mc manager: %w", err)
+	}
+
+	// A simple controller that logs ConfigMaps per owned “cluster” (namespace).
+	if err := mcbuilder.ControllerManagedBy(mgr).
+		Named("multicluster-configmaps").
+		For(&corev1.ConfigMap{}).
+		Complete(mcreconcile.Func(func(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
+			// attach cluster once; don't repeat it in Info()
+			l := ctrl.LoggerFrom(ctx).WithValues("cluster", req.ClusterName)
+
+			// get the right cluster client
+			cl, err := mgr.GetCluster(ctx, req.ClusterName)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			// fetch the object, then log from the object (truth)
+			cm := &corev1.ConfigMap{}
+			if err := cl.GetClient().Get(ctx, req.Request.NamespacedName, cm); err != nil {
+				if apierrors.IsNotFound(err) {
+					// object vanished — nothing to do
+					return ctrl.Result{}, nil
+				}
+				return ctrl.Result{}, err
+			}
+
+			// now cm.Namespace is accurate (e.g., "zoo", "kube-system", etc.)
+			l.Info("Reconciling ConfigMap",
+				"ns", cm.GetNamespace(),
+				"name", cm.GetName(),
+			)
+
+			// show which peer handled it (pod hostname)
+			if host, _ := os.Hostname(); host != "" {
+				l.Info("Handled by peer", "peer", host)
+			}
+			return ctrl.Result{}, nil
+		})); err != nil {
+		return fmt.Errorf("build controller: %w", err)
+	}
+
+	// Start everything
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error { return ignoreCanceled(host.Start(ctx)) })
+	g.Go(func() error { return ignoreCanceled(mgr.Start(ctx)) })
+	return g.Wait()
+}
+
+func ignoreCanceled(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}

--- a/examples/sharded-namespace/manifests/kustomization.yaml
+++ b/examples/sharded-namespace/manifests/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - statefulset.yaml
+  - sample-data.yaml

--- a/examples/sharded-namespace/manifests/rbac.yaml
+++ b/examples/sharded-namespace/manifests/rbac.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcr-demo
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mcr-demo
+  namespace: mcr-demo
+---
+# Allow reading/writing peer Leases in kube-system
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcr-lease
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get","list","watch","create","update","patch","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mcr-lease
+subjects:
+- kind: ServiceAccount
+  name: mcr-demo
+  namespace: mcr-demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mcr-lease
+---
+# Allow the example to read namespaces/configmaps (namespace provider + demo controller)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcr-example
+rules:
+- apiGroups: [""]
+  resources: ["namespaces","configmaps"]
+  verbs: ["get","list","watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mcr-example
+subjects:
+- kind: ServiceAccount
+  name: mcr-demo
+  namespace: mcr-demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mcr-example

--- a/examples/sharded-namespace/manifests/sample-data.yaml
+++ b/examples/sharded-namespace/manifests/sample-data.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zoo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elephant
+  namespace: zoo
+data: { a: "1" }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lion
+  namespace: zoo
+data: { a: "1" }
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jungle
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monkey
+  namespace: jungle
+data: { a: "1" }
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: island
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bird
+  namespace: island
+data: { a: "1" }

--- a/examples/sharded-namespace/manifests/statefulset.yaml
+++ b/examples/sharded-namespace/manifests/statefulset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sharded-namespace
+  namespace: mcr-demo
+spec:
+  serviceName: sharded-namespace
+  replicas: 2
+  selector:
+    matchLabels:
+      app: sharded-namespace
+  template:
+    metadata:
+      labels:
+        app: sharded-namespace
+    spec:
+      serviceAccountName: mcr-demo
+      containers:
+      - name: app
+        image: mcr-namespace:dev # change to your image name
+        imagePullPolicy: IfNotPresent
+        # No env needed; hostname == pod name → unique peer ID automatically

--- a/pkg/manager/coordinator.go
+++ b/pkg/manager/coordinator.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+)
+
+// Coordinator controls per-cluster lifecycle for multicluster-aware runnables.
+// Implementations may simply engage everything or perform sharding/fencing.
+//
+// EXPERIMENTAL: Coordinator is not a stable API and may change without notice.
+type Coordinator interface {
+	// AddRunnable registers a multicluster-aware component to be engaged for
+	// clusters this coordinator activates. Safe to call before any Engage.
+	AddRunnable(multicluster.Aware)
+
+	// Engage informs the coordinator about a cluster that is now available.
+	// The coordinator may start or delay runnables for this cluster based on
+	// its policy. ctx is cancelled when the cluster is removed; implementations
+	// should stop per-cluster work promptly on cancellation.
+	Engage(ctx context.Context, name string, cl cluster.Cluster) error
+
+	// Runnable returns an optional background Runnable driving coordination
+	// (e.g., membership refresh, fencing). Return nil if no background work
+	// is needed.
+	Runnable() manager.Runnable
+}
+
+// WithCoordinator sets a custom Coordinator. EXPERIMENTAL: not a stable API.
+func WithCoordinator(c Coordinator) Option {
+	return func(m *mcManager) {
+		m.coord = c
+	}
+}

--- a/pkg/manager/coordinator/basic/basic.go
+++ b/pkg/manager/coordinator/basic/basic.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+)
+
+// Coordinator engages all clusters immediately without sharding or fencing.
+type Coordinator struct {
+	mu        sync.Mutex
+	runnables []multicluster.Aware
+}
+
+// New returns a basic coordinator that engages every cluster.
+func New() *Coordinator {
+	return &Coordinator{}
+}
+
+// AddRunnable registers a multicluster-aware runnable.
+func (c *Coordinator) AddRunnable(r multicluster.Aware) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.runnables = append(c.runnables, r)
+}
+
+// Engage runs Engage on all registered runnables for this cluster.
+func (c *Coordinator) Engage(ctx context.Context, name string, cl cluster.Cluster) error {
+	c.mu.Lock()
+	rs := append([]multicluster.Aware(nil), c.runnables...)
+	c.mu.Unlock()
+	for _, r := range rs {
+		if err := r.Engage(ctx, name, cl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Runnable returns nil because the basic coordinator has no background work.
+func (c *Coordinator) Runnable() manager.Runnable { return nil }

--- a/pkg/manager/coordinator/sharded/coordinator.go
+++ b/pkg/manager/coordinator/sharded/coordinator.go
@@ -1,0 +1,371 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharded
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded/peers"
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded/sharder"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+	"sigs.k8s.io/multicluster-runtime/pkg/util/sanitize"
+)
+
+// Config holds the knobs for shard synchronization and fencing.
+//
+// Fencing:
+//   - FenceNS/FencePrefix: namespace and name prefix for per-shard Lease objects
+//     (e.g. mcr-shard-<cluster> when PerClusterLease is true).
+//   - PerClusterLease: when true, use one Lease per cluster (recommended). When false,
+//     use a single shared fence name for all clusters.
+//   - LeaseDuration / LeaseRenew: total TTL and renew cadence. Choose renew < duration
+//     (commonly renew ≈ duration/3).
+//   - FenceThrottle: backoff before retrying failed fence acquisition, to reduce API churn.
+//
+// Peers (membership):
+//   - PeerPrefix: prefix used by the peer registry for membership Leases.
+//   - PeerWeight: relative capacity hint used by the sharder (0 treated as 1).
+//
+// Cadence:
+//   - Probe: periodic synchronization tick interval (decision loop).
+//   - Rehash: optional slower cadence for planned redistribution (unused in basic HRW).
+type Config struct {
+	// FenceNS is the namespace where fence Leases live (usually "kube-system").
+	FenceNS string
+	// FencePrefix is the base Lease name for fences; with PerClusterLease it becomes
+	// FencePrefix+"-"+<cluster> (e.g., "mcr-shard-zoo").
+	FencePrefix string
+	// PerClusterLease controls whether we create one fence per cluster (true) or a
+	// single shared fence name (false). Per-cluster is recommended.
+	PerClusterLease bool
+	// LeaseDuration is the total TTL written to the Lease (spec.LeaseDurationSeconds).
+	LeaseDuration time.Duration
+	// LeaseRenew is the renewal cadence; must be < LeaseDuration (rule of thumb ≈ 1/3).
+	LeaseRenew time.Duration
+	// FenceThrottle backs off repeated failed TryAcquire attempts to reduce API churn.
+	FenceThrottle time.Duration
+
+	// PeerPrefix is the Lease name prefix used by the peer registry for membership.
+	PeerPrefix string
+	// PeerWeight is this peer’s capacity hint for HRW (0 treated as 1).
+	PeerWeight uint32
+
+	// Probe is the synchronization decision loop interval.
+	Probe time.Duration
+	// Rehash is an optional slower cadence for planned redistribution (currently unused).
+	Rehash time.Duration
+}
+
+// Option mutates a sharded Coordinator before use.
+type Option func(*Coordinator)
+
+// Coordinator makes synchronization decisions and starts/stops per-cluster work.
+//
+// It combines:
+//   - a peerRegistry (live peer snapshot),
+//   - a sharder (e.g., HRW) to decide "who should own",
+//   - a per-cluster leaseGuard to fence "who actually runs".
+//
+// The coordinator keeps per-cluster engagement state, ties watches/workers to an
+// engagement context, and uses the fence to guarantee single-writer semantics.
+type Coordinator struct {
+	// kube is the host cluster client used for Leases and provider operations.
+	kube client.Client
+	// log is the coordinator’s logger.
+	log logr.Logger
+	// sharder decides “shouldOwn” given clusterID, peers, and self (e.g., HRW).
+	sharder sharder.Sharder
+	// peers provides a live membership snapshot for sharding decisions.
+	peers peers.Registry
+	// self is this process’s identity/weight as known by the peer registry.
+	self sharder.PeerInfo
+	// cfg holds all synchronization/fencing configuration.
+	cfg Config
+
+	// mu guards engaged and runnables.
+	mu sync.Mutex
+	// engaged tracks per-cluster engagement state keyed by cluster name.
+	engaged map[string]*engagement
+	// runnables are the multicluster components to (de)start per cluster.
+	runnables []multicluster.Aware
+}
+
+// engagement tracks per-cluster lifecycle within the coordinator.
+//
+// ctx/cancel: engagement context; cancellation stops sources/workers.
+// started: whether runnables have been engaged for this cluster.
+// fence: the per-cluster Lease guard (nil until first start attempt).
+// nextTry: throttle timestamp for fence acquisition retries.
+type engagement struct {
+	// name is the cluster identifier (e.g., namespace).
+	name string
+	// cl is the controller-runtime cluster handle for this engagement.
+	cl cluster.Cluster
+	// ctx is the engagement context; cancelling it stops sources/work.
+	ctx context.Context
+	// cancel cancels ctx.
+	cancel context.CancelFunc
+	// started is true after runnables have been engaged for this cluster.
+	started bool
+
+	// fence is the per-cluster Lease guard (nil until first start attempt).
+	fence *leaseGuard
+	// nextTry defers the next TryAcquire attempt until this time (throttling).
+	nextTry time.Time
+}
+
+// New returns a sharded Coordinator with defaults; options apply overrides.
+func New(kube client.Client, log logr.Logger, opts ...Option) *Coordinator {
+	c := &Coordinator{
+		kube:    kube,
+		log:     log,
+		cfg:     defaultConfig(),
+		sharder: sharder.NewHRW(),
+		engaged: make(map[string]*engagement),
+	}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	// Default peer registry if not injected.
+	if c.peers == nil {
+		c.peers = peers.NewLeaseRegistry(kube, c.cfg.FenceNS, c.cfg.PeerPrefix, "", c.cfg.PeerWeight, log)
+	}
+
+	c.self = c.peers.Self()
+	return c
+}
+
+func defaultConfig() Config {
+	return Config{
+		FenceNS: "kube-system", FencePrefix: "mcr-shard", PerClusterLease: true,
+		LeaseDuration: 20 * time.Second, LeaseRenew: 10 * time.Second, FenceThrottle: 750 * time.Millisecond,
+		PeerPrefix: "mcr-peer", PeerWeight: 1,
+		Probe: 5 * time.Second, Rehash: 15 * time.Second,
+	}
+}
+
+func (c *Coordinator) fenceName(cluster string) string {
+	if c.cfg.PerClusterLease {
+		return fmt.Sprintf("%s-%s", c.cfg.FencePrefix, sanitize.DNS1123(cluster))
+	}
+	return c.cfg.FencePrefix
+}
+
+// Runnable returns a Runnable that manages synchronization of clusters.
+func (c *Coordinator) Runnable() manager.Runnable {
+	return manager.RunnableFunc(func(ctx context.Context) error {
+		c.log.Info("synchronization runnable starting", "peer", c.self.ID)
+		errCh := make(chan error, 1)
+		go func() { errCh <- c.peers.Run(ctx) }()
+		c.recompute(ctx)
+		t := time.NewTicker(c.cfg.Probe)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case err := <-errCh:
+				return err
+			case <-t.C:
+				c.log.V(1).Info("coordination tick", "peers", len(c.peers.Snapshot()))
+				c.recompute(ctx)
+			}
+		}
+	})
+}
+
+// Engage registers a cluster for coordination.
+func (c *Coordinator) Engage(parent context.Context, name string, cl cluster.Cluster) error {
+	if err := parent.Err(); err != nil {
+		return err
+	}
+
+	var doRecompute bool
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if cur, ok := c.engaged[name]; ok {
+		// Re-engage same name: replace token; stop old engagement; preserve fence.
+		var fence *leaseGuard
+		if cur.fence != nil {
+			fence = cur.fence // keep the existing fence/renewer
+		}
+		if cur.cancel != nil {
+			cur.cancel() // stop old sources/workers
+		}
+
+		newEng := &engagement{name: name, cl: cl, fence: fence}
+		c.engaged[name] = newEng
+
+		// cleanup tied to the *new* token; old goroutine will no-op (ee != token)
+		go func(pctx context.Context, key string, token *engagement) {
+			<-pctx.Done()
+			c.mu.Lock()
+			if ee, ok := c.engaged[key]; ok && ee == token {
+				if ee.started && ee.cancel != nil {
+					ee.cancel()
+				}
+				if ee.fence != nil {
+					go ee.fence.Release(context.Background())
+				}
+				delete(c.engaged, key)
+			}
+			c.mu.Unlock()
+		}(parent, name, newEng)
+
+		doRecompute = true
+	} else {
+		eng := &engagement{name: name, cl: cl}
+		c.engaged[name] = eng
+		go func(pctx context.Context, key string, token *engagement) {
+			<-pctx.Done()
+			c.mu.Lock()
+			if ee, ok := c.engaged[key]; ok && ee == token {
+				if ee.started && ee.cancel != nil {
+					ee.cancel()
+				}
+				if ee.fence != nil {
+					go ee.fence.Release(context.Background())
+				}
+				delete(c.engaged, key)
+			}
+			c.mu.Unlock()
+		}(parent, name, eng)
+		doRecompute = true
+	}
+
+	// Kick a decision outside the lock for faster attach.
+	if doRecompute {
+		go c.recompute(parent)
+	}
+
+	return nil
+}
+
+func (c *Coordinator) recompute(parent context.Context) {
+	peers := c.peers.Snapshot()
+	self := c.self
+
+	type toStart struct {
+		name string
+		cl   cluster.Cluster
+		ctx  context.Context
+	}
+	var starts []toStart
+	var stops []context.CancelFunc
+
+	now := time.Now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for name, engm := range c.engaged {
+		should := c.sharder.ShouldOwn(name, peers, self)
+
+		switch {
+		case should && !engm.started:
+			// ensure fence exists
+			if engm.fence == nil {
+				onLost := func(cluster string) func() {
+					return func() {
+						// best-effort stop if we lose the lease mid-flight
+						c.log.Info("lease lost; stopping", "cluster", cluster, "peer", self.ID)
+						c.mu.Lock()
+						if ee := c.engaged[cluster]; ee != nil && ee.started && ee.cancel != nil {
+							ee.cancel()
+							ee.started = false
+						}
+						c.mu.Unlock()
+					}
+				}(name)
+				engm.fence = newLeaseGuard(
+					c.kube,
+					c.cfg.FenceNS, c.fenceName(name), c.self.ID,
+					c.cfg.LeaseDuration, c.cfg.LeaseRenew, onLost,
+				)
+			}
+
+			// throttle attempts
+			if now.Before(engm.nextTry) {
+				continue
+			}
+
+			// try to take the fence; if we fail, set nextTry and retry on next tick
+			if !engm.fence.TryAcquire(parent) {
+				engm.nextTry = now.Add(c.cfg.FenceThrottle)
+				continue
+			}
+
+			// acquired fence; start the cluster
+			ctx, cancel := context.WithCancel(parent)
+			engm.ctx, engm.cancel, engm.started = ctx, cancel, true
+			starts = append(starts, toStart{name: engm.name, cl: engm.cl, ctx: ctx})
+			c.log.Info("synchronization start", "cluster", name, "peer", self.ID)
+
+		case !should && engm.started:
+			// stop + release fence
+			if engm.cancel != nil {
+				stops = append(stops, engm.cancel)
+			}
+			if engm.fence != nil {
+				go engm.fence.Release(parent)
+			}
+			engm.cancel = nil
+			engm.started = false
+			engm.nextTry = time.Time{}
+			c.log.Info("synchronization stop", "cluster", name, "peer", self.ID)
+		}
+	}
+	for _, c := range stops {
+		c()
+	}
+	for _, s := range starts {
+		go c.startForCluster(s.ctx, s.name, s.cl)
+	}
+}
+
+func (c *Coordinator) startForCluster(ctx context.Context, name string, cl cluster.Cluster) {
+	for _, r := range c.runnables {
+		if err := r.Engage(ctx, name, cl); err != nil {
+			c.log.Error(err, "failed to engage", "cluster", name)
+			// best-effort: cancel + mark stopped so next tick can retry
+			c.mu.Lock()
+			if engm := c.engaged[name]; engm != nil && engm.cancel != nil {
+				engm.cancel()
+				engm.started = false
+			}
+			c.mu.Unlock()
+			return
+		}
+	}
+}
+
+// AddRunnable registers a multicluster-aware runnable.
+func (c *Coordinator) AddRunnable(r multicluster.Aware) {
+	c.runnables = append(c.runnables, r)
+}

--- a/pkg/manager/coordinator/sharded/envtest_suite_test.go
+++ b/pkg/manager/coordinator/sharded/envtest_suite_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharded_test
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCoordinator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sharded Coordinator Suite")
+}
+
+var testEnv *envtest.Environment
+var cfg *rest.Config
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	testEnv = &envtest.Environment{}
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	// Prevent the metrics listener being created
+	metricsserver.DefaultBindAddress = "0"
+})
+
+var _ = AfterSuite(func() {
+	if testEnv != nil {
+		Expect(testEnv.Stop()).To(Succeed())
+	}
+	// Put the DefaultBindAddress back
+	metricsserver.DefaultBindAddress = ":8080"
+})

--- a/pkg/manager/coordinator/sharded/leaseguard.go
+++ b/pkg/manager/coordinator/sharded/leaseguard.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharded
+
+import (
+	"context"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// leaseGuard manages a single Lease as a *fence* for one shard/cluster.
+//
+// Design/semantics:
+//
+//   - TryAcquire(ctx) attempts to create/adopt the Lease for holder `id`,
+//     and, on success, starts a background renew loop. It is idempotent:
+//     calling it while already held is a cheap true.
+//
+//   - Renewing: a ticker renews the Lease every `renew`. If renewal fails
+//     (API error, conflict, or we observe another holder while still valid),
+//     `onLost` is invoked once (best-effort), the fence is released, and the
+//     loop exits.
+//
+//   - Release(ctx) stops renewing and, if we still own the Lease, clears
+//     HolderIdentity (best-effort). Safe to call multiple times.
+//
+//   - Thread-safety: leaseGuard is intended to be used by a single goroutine
+//     (caller) per fence. External synchronization is required if multiple
+//     goroutines might call its methods concurrently.
+//
+//   - Timings: choose ldur (duration) > renew. A common pattern is
+//     renew ≈ ldur/3. Too small ldur increases churn; too large slows
+//     failover.
+//
+// RBAC: the caller’s client must be allowed to get/list/watch/create/update/patch
+// Leases in namespace `ns`.
+type leaseGuard struct {
+	c      client.Client
+	ns, nm string
+	id     string
+	ldur   time.Duration // lease duration
+	renew  time.Duration // renew period
+	onLost func()        // callback when we lose the lease
+
+	held   bool
+	cancel context.CancelFunc
+}
+
+// newLeaseGuard builds a guard; it does not contact the API server.
+func newLeaseGuard(c client.Client, ns, name, id string, ldur, renew time.Duration, onLost func()) *leaseGuard {
+	return &leaseGuard{c: c, ns: ns, nm: name, id: id, ldur: ldur, renew: renew, onLost: onLost}
+}
+
+// TryAcquire creates/adopts the Lease for g.id and starts renewing it.
+// Returns true iff we own it after this call (or already owned).
+// Fails (returns false) when another non-expired holder exists or API calls error.
+func (g *leaseGuard) TryAcquire(ctx context.Context) bool {
+	if g.held {
+		return true
+	}
+
+	key := types.NamespacedName{Namespace: g.ns, Name: g.nm}
+	now := metav1.NowMicro()
+
+	ldurSec := int32(g.ldur / time.Second)
+
+	var ls coordinationv1.Lease
+	err := g.c.Get(ctx, key, &ls)
+	switch {
+	case apierrors.IsNotFound(err):
+		ls = coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Namespace: g.ns, Name: g.nm},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       &g.id,
+				LeaseDurationSeconds: &ldurSec,
+				AcquireTime:          &now,
+				RenewTime:            &now,
+			},
+		}
+		if err := g.c.Create(ctx, &ls); err != nil {
+			return false
+		}
+	case err != nil:
+		return false
+	default:
+		// adopt if free/expired/ours
+		ho := ""
+		if ls.Spec.HolderIdentity != nil {
+			ho = *ls.Spec.HolderIdentity
+		}
+		if ho != "" && ho != g.id {
+			if !expired(&ls, now) {
+				return false
+			}
+		}
+		ls.Spec.HolderIdentity = &g.id
+		ls.Spec.LeaseDurationSeconds = &ldurSec
+		// keep first AcquireTime if already ours, otherwise set it
+		if ho != g.id || ls.Spec.AcquireTime == nil {
+			ls.Spec.AcquireTime = &now
+		}
+		ls.Spec.RenewTime = &now
+		if err := g.c.Update(ctx, &ls); err != nil {
+			return false
+		}
+	}
+
+	// we own it; start renewer
+	rctx, cancel := context.WithCancel(context.Background())
+	g.cancel = cancel
+	g.held = true
+	go g.renewLoop(rctx, key)
+	return true
+}
+
+// Internal: renew loop and single-step renew. If renewal observes a different,
+// valid holder or API errors persist, onLost() is invoked once and the fence is released.
+func (g *leaseGuard) renewLoop(ctx context.Context, key types.NamespacedName) {
+	t := time.NewTicker(g.renew)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if ok := g.renewOnce(ctx, key); !ok {
+				// best-effort notify once, then release
+				if g.onLost != nil {
+					g.onLost()
+				}
+				g.Release(context.Background())
+				return
+			}
+		}
+	}
+}
+
+func (g *leaseGuard) renewOnce(ctx context.Context, key types.NamespacedName) bool {
+	now := metav1.NowMicro()
+	var ls coordinationv1.Lease
+	if err := g.c.Get(ctx, key, &ls); err != nil {
+		return false
+	}
+	// another holder?
+	if ls.Spec.HolderIdentity != nil && *ls.Spec.HolderIdentity != g.id && !expired(&ls, now) {
+		return false
+	}
+	ldurSec := int32(g.ldur / time.Second)
+	// update
+	ls.Spec.HolderIdentity = &g.id
+	ls.Spec.LeaseDurationSeconds = &ldurSec
+	ls.Spec.RenewTime = &now
+	if err := g.c.Update(ctx, &ls); err != nil {
+		return false
+	}
+	return true
+}
+
+// Release stops renewing; best-effort clear if we still own it.
+func (g *leaseGuard) Release(ctx context.Context) {
+	if !g.held {
+		return
+	}
+	if g.cancel != nil {
+		g.cancel()
+	}
+	g.held = false
+
+	key := types.NamespacedName{Namespace: g.ns, Name: g.nm}
+	var ls coordinationv1.Lease
+	if err := g.c.Get(ctx, key, &ls); err == nil {
+		if ls.Spec.HolderIdentity != nil && *ls.Spec.HolderIdentity == g.id {
+			empty := ""
+			ls.Spec.HolderIdentity = &empty
+			// keep RenewTime/AcquireTime; just clear holder
+			_ = g.c.Update(ctx, &ls) // ignore errors
+		}
+	}
+}
+
+func expired(ls *coordinationv1.Lease, now metav1.MicroTime) bool {
+	if ls.Spec.RenewTime == nil || ls.Spec.LeaseDurationSeconds == nil {
+		return true
+	}
+	return now.Time.After(ls.Spec.RenewTime.Time.Add(time.Duration(*ls.Spec.LeaseDurationSeconds) * time.Second))
+}

--- a/pkg/manager/coordinator/sharded/leaseguard_test.go
+++ b/pkg/manager/coordinator/sharded/leaseguard_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharded
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// test constants
+const (
+	testNS   = "kube-system"
+	testName = "mcr-shard-default"
+	testID   = "peer-0"
+	otherID  = "peer-1"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := coordinationv1.AddToScheme(s); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	return s
+}
+
+func getLease(t *testing.T, c crclient.Client) *coordinationv1.Lease {
+	t.Helper()
+	var ls coordinationv1.Lease
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: testNS, Name: testName}, &ls); err != nil {
+		t.Fatalf("get lease: %v", err)
+	}
+	return &ls
+}
+
+func makeLease(holder string, renewAgo time.Duration, durSec int32) *coordinationv1.Lease {
+	now := time.Now()
+	renew := metav1.NewMicroTime(now.Add(-renewAgo))
+	return &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNS, Name: testName},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       &holder,
+			LeaseDurationSeconds: &durSec,
+			RenewTime:            &renew,
+			AcquireTime:          &renew,
+		},
+	}
+}
+
+func TestTryAcquire_CreatesAndRenewsThenReleaseClearsHolder(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	onLostCh := make(chan struct{}, 1)
+	g := newLeaseGuard(c, testNS, testName, testID, 3*time.Second, 200*time.Millisecond, func() { onLostCh <- struct{}{} })
+
+	if ok := g.TryAcquire(context.Background()); !ok {
+		t.Fatalf("expected TryAcquire to succeed on create")
+	}
+	if !g.held {
+		t.Fatalf("guard should be held after TryAcquire")
+	}
+
+	ls := getLease(t, c)
+	if ls.Spec.HolderIdentity == nil || *ls.Spec.HolderIdentity != testID {
+		t.Fatalf("holder mismatch, got %v", ls.Spec.HolderIdentity)
+	}
+	if ls.Spec.LeaseDurationSeconds == nil || *ls.Spec.LeaseDurationSeconds != int32(3) {
+		t.Fatalf("duration mismatch, got %v", ls.Spec.LeaseDurationSeconds)
+	}
+
+	// Idempotent
+	if ok := g.TryAcquire(context.Background()); !ok {
+		t.Fatalf("expected idempotent TryAcquire to return true")
+	}
+
+	// Release clears holder (best-effort)
+	g.Release(context.Background())
+	ls = getLease(t, c)
+	if ls.Spec.HolderIdentity != nil && *ls.Spec.HolderIdentity != "" {
+		t.Fatalf("expected holder cleared on release, got %q", *ls.Spec.HolderIdentity)
+	}
+}
+
+func TestTryAcquire_FailsWhenOtherHoldsAndNotExpired(t *testing.T) {
+	s := newScheme(t)
+	// Other holder renewed recently, not expired
+	dur := int32(30)
+	ls := makeLease(otherID, 1*time.Second, dur)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ls).Build()
+
+	g := newLeaseGuard(c, testNS, testName, testID, 10*time.Second, 2*time.Second, nil)
+
+	if ok := g.TryAcquire(context.Background()); ok {
+		t.Fatalf("expected TryAcquire to fail while another valid holder exists")
+	}
+	if g.held {
+		t.Fatalf("guard should not be held")
+	}
+}
+
+func TestTryAcquire_AdoptsWhenExpired(t *testing.T) {
+	s := newScheme(t)
+	// Other holder expired: renew time far in the past relative to duration
+	dur := int32(5)
+	ls := makeLease(otherID, 30*time.Second, dur)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ls).Build()
+
+	g := newLeaseGuard(c, testNS, testName, testID, 10*time.Second, 2*time.Second, nil)
+
+	if ok := g.TryAcquire(context.Background()); !ok {
+		t.Fatalf("expected TryAcquire to adopt expired lease")
+	}
+	got := getLease(t, c)
+	if got.Spec.HolderIdentity == nil || *got.Spec.HolderIdentity != testID {
+		t.Fatalf("expected holder=%q, got %v", testID, got.Spec.HolderIdentity)
+	}
+}
+
+func TestRenewLoop_OnLostTriggersCallbackAndReleases(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	lost := make(chan struct{}, 1)
+	g := newLeaseGuard(c, testNS, testName, testID, 3*time.Second, 50*time.Millisecond, func() { lost <- struct{}{} })
+
+	// Acquire
+	if ok := g.TryAcquire(context.Background()); !ok {
+		t.Fatalf("expected TryAcquire to succeed")
+	}
+
+	// Flip lease to another holder (valid) so renewOnce observes loss.
+	ls := getLease(t, c)
+	now := metav1.NowMicro()
+	dur := int32(3)
+	other := otherID
+	ls.Spec.HolderIdentity = &other
+	ls.Spec.LeaseDurationSeconds = &dur
+	ls.Spec.RenewTime = &now
+	if err := c.Update(context.Background(), ls); err != nil {
+		t.Fatalf("update lease: %v", err)
+	}
+
+	// Expect onLost to fire and guard to release within a few renew ticks
+	select {
+	case <-lost:
+		// ok
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected onLost to be called after renewal detects loss")
+	}
+
+	// Give a moment for Release() to run
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got := getLease(t, c)
+		if got.Spec.HolderIdentity == nil || *got.Spec.HolderIdentity == "" || *got.Spec.HolderIdentity != testID {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("expected holder to be cleared or moved after loss")
+}
+
+func TestRelease_NoHoldIsNoop(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	g := newLeaseGuard(c, testNS, testName, testID, 3*time.Second, 1*time.Second, nil)
+	// Not acquired yet; should be a no-op
+	g.Release(context.Background())
+	// Nothing to assert other than "does not panic"
+}

--- a/pkg/manager/coordinator/sharded/options.go
+++ b/pkg/manager/coordinator/sharded/options.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharded
+
+import (
+	"time"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded/peers"
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded/sharder"
+)
+
+// WithSharder replaces the default HRW sharder.
+func WithSharder(s sharder.Sharder) Option {
+	return func(c *Coordinator) {
+		if s != nil {
+			c.sharder = s
+		}
+	}
+}
+
+// WithPeerWeight allows heterogeneous peers (capacity hint).
+// Effective share tends toward w_i/Σw under many shards.
+func WithPeerWeight(w uint32) Option {
+	return func(c *Coordinator) {
+		c.cfg.PeerWeight = w
+	}
+}
+
+// WithShardLease configures the fencing Lease ns/prefix (mcr-shard-* by default).
+func WithShardLease(ns, name string) Option {
+	return func(c *Coordinator) {
+		c.cfg.FenceNS = ns
+		c.cfg.FencePrefix = name
+	}
+}
+
+// WithPerClusterLease enables/disables per-cluster fencing (true -> mcr-shard-<cluster>).
+func WithPerClusterLease(on bool) Option {
+	return func(c *Coordinator) {
+		c.cfg.PerClusterLease = on
+	}
+}
+
+// WithSynchronizationIntervals tunes the synchronization probe/rehash cadences.
+func WithSynchronizationIntervals(probe, rehash time.Duration) Option {
+	return func(c *Coordinator) {
+		c.cfg.Probe = probe
+		c.cfg.Rehash = rehash
+	}
+}
+
+// WithLeaseTimings configures fencing lease timings.
+func WithLeaseTimings(duration, renew, throttle time.Duration) Option {
+	return func(c *Coordinator) {
+		c.cfg.LeaseDuration = duration
+		c.cfg.LeaseRenew = renew
+		c.cfg.FenceThrottle = throttle
+	}
+}
+
+// WithPeerRegistry injects a custom peer Registry. When set, it overrides the
+// default Lease-based registry. Peer weight should be provided by the custom
+// registry; WithPeerWeight does not apply.
+func WithPeerRegistry(reg peers.Registry) Option {
+	return func(c *Coordinator) {
+		if reg != nil {
+			c.peers = reg
+			c.self = reg.Self()
+		}
+	}
+}
+
+// withConfig replaces the full config (for tests only; not exported).
+func withConfig(cfg Config) Option {
+	return func(c *Coordinator) {
+		c.cfg = cfg
+	}
+}

--- a/pkg/manager/coordinator/sharded/peers/doc.go
+++ b/pkg/manager/coordinator/sharded/peers/doc.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package peers implements a lightweight membership registry for sharding.
+
+Each peer advertises presence via a coordination.k8s.io/Lease named
+<prefix>-<peerID> (e.g. mcr-peer-sharded-namespace-0). The registry:
+
+  - upserts our own Lease on a cadence (heartbeat),
+  - lists other peer Leases with matching labels/prefix,
+  - exposes a stable snapshot for HRW/placement.
+
+This registry only tracks membership; single-writer ownership is enforced
+separately via per-cluster fencing Leases.
+*/
+package peers

--- a/pkg/manager/coordinator/sharded/peers/registry.go
+++ b/pkg/manager/coordinator/sharded/peers/registry.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package peers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	coordv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded/sharder"
+	"sigs.k8s.io/multicluster-runtime/pkg/util/sanitize"
+)
+
+const (
+	labelPartOf   = "app.kubernetes.io/part-of"
+	labelPeer     = "mcr.sigs.k8s.io/peer"
+	labelPrefix   = "mcr.sigs.k8s.io/prefix"
+	annotWeight   = "mcr.sigs.k8s.io/weight"
+	partOfValue   = "multicluster-runtime"
+	defaultWeight = uint32(1)
+)
+
+// Registry provides peer membership for sharding decisions.
+type Registry interface {
+	// Self returns this process's identity and weight.
+	Self() sharder.PeerInfo
+	// Snapshot returns the current set of live peers. Treat as read-only.
+	Snapshot() []sharder.PeerInfo
+	// Run blocks, periodically renewing our Lease and refreshing peer membership
+	// until ctx is cancelled or an error occurs.
+	Run(ctx context.Context) error
+}
+
+type leaseRegistry struct {
+	ns, namePrefix string
+	self           sharder.PeerInfo
+	cli            crclient.Client
+
+	mu    sync.RWMutex
+	peers map[string]sharder.PeerInfo
+
+	ttl   time.Duration
+	renew time.Duration
+
+	log logr.Logger
+}
+
+// NewLeaseRegistry constructs a Lease-based Registry.
+//
+// Params:
+//   - ns: namespace where peer Leases live (e.g. "kube-system")
+//   - namePrefix: Lease name prefix (e.g. "mcr-peer")
+//   - selfID: this process ID (defaults to os.Hostname() if empty)
+//   - weight: relative capacity (0 treated as 1)
+//   - log: logger; use logr.Discard() to silence
+func NewLeaseRegistry(cli crclient.Client, ns, namePrefix string, selfID string, weight uint32, log logr.Logger) Registry {
+	if selfID == "" {
+		if hn, _ := os.Hostname(); hn != "" {
+			selfID = hn
+		} else {
+			selfID = "unknown"
+		}
+	}
+	// Sanitize to DNS-1123 subdomain for Lease names: lowercase, [a-z0-9-.], start/end alphanumeric.
+	selfID = sanitize.DNS1123(selfID)
+	if weight == 0 {
+		weight = defaultWeight
+	}
+	return &leaseRegistry{
+		ns:         ns,
+		namePrefix: namePrefix,
+		self:       sharder.PeerInfo{ID: selfID, Weight: weight},
+		cli:        cli,
+		peers:      map[string]sharder.PeerInfo{},
+		ttl:        30 * time.Second,
+		renew:      10 * time.Second,
+		log:        log.WithName("lease-registry").WithValues("ns", ns, "prefix", namePrefix, "selfID", selfID, "weight", weight),
+	}
+}
+
+func (r *leaseRegistry) Self() sharder.PeerInfo { return r.self }
+
+func (r *leaseRegistry) Snapshot() []sharder.PeerInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]sharder.PeerInfo, 0, len(r.peers))
+	for _, p := range r.peers {
+		out = append(out, p)
+	}
+	return out
+}
+
+func (r *leaseRegistry) Run(ctx context.Context) error {
+	r.log.Info("peer registry starting", "ns", r.ns, "prefix", r.namePrefix, "self", r.self.ID)
+
+	// Tick frequently enough to renew well within ttl.
+	t := time.NewTicker(r.renew)
+	defer t.Stop()
+
+	for {
+		// Do one pass immediately so we publish our presence promptly.
+		if err := r.renewSelfLease(ctx); err != nil && ctx.Err() == nil {
+			r.log.V(1).Info("renewSelfLease failed; will retry", "err", err)
+		}
+		if err := r.refreshPeers(ctx); err != nil && ctx.Err() == nil {
+			r.log.V(1).Info("refreshPeers failed; will retry", "err", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			// loop
+		}
+	}
+}
+
+// renewSelfLease upserts our own Lease with fresh RenewTime and duration.
+func (r *leaseRegistry) renewSelfLease(ctx context.Context) error {
+	now := metav1.MicroTime{Time: time.Now()}
+	ttlSec := int32(r.ttl / time.Second)
+	name := fmt.Sprintf("%s-%s", r.namePrefix, r.self.ID)
+
+	lease := &coordv1.Lease{}
+	err := r.cli.Get(ctx, crclient.ObjectKey{Namespace: r.ns, Name: name}, lease)
+	switch {
+	case apierrors.IsNotFound(err):
+		lease = &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: r.ns,
+				Name:      name,
+				Labels: map[string]string{
+					labelPartOf: partOfValue,
+					labelPeer:   "true",
+					labelPrefix: r.namePrefix,
+				},
+				Annotations: map[string]string{
+					annotWeight: strconv.FormatUint(uint64(r.self.Weight), 10),
+				},
+			},
+			Spec: coordv1.LeaseSpec{
+				HolderIdentity:       ptr.To(r.self.ID),
+				RenewTime:            &now,
+				LeaseDurationSeconds: ptr.To(ttlSec),
+			},
+		}
+		return r.cli.Create(ctx, lease)
+
+	case err != nil:
+		return err
+
+	default:
+		// Update the existing Lease
+		lease.Spec.HolderIdentity = ptr.To(r.self.ID)
+		lease.Spec.RenewTime = &now
+		lease.Spec.LeaseDurationSeconds = ptr.To(ttlSec)
+		if lease.Annotations == nil {
+			lease.Annotations = map[string]string{}
+		}
+		lease.Annotations[annotWeight] = strconv.FormatUint(uint64(r.self.Weight), 10)
+		return r.cli.Update(ctx, lease)
+	}
+}
+
+// refreshPeers lists peer Leases and updates the in-memory snapshot.
+func (r *leaseRegistry) refreshPeers(ctx context.Context) error {
+	list := &coordv1.LeaseList{}
+	// Only list our labeled peer leases with our prefix for efficiency.
+	if err := r.cli.List(ctx, list,
+		crclient.InNamespace(r.ns),
+		crclient.MatchingLabels{
+			labelPeer:   "true",
+			labelPrefix: r.namePrefix,
+		},
+	); err != nil {
+		return err
+	}
+
+	now := time.Now()
+	next := make(map[string]sharder.PeerInfo, len(list.Items))
+
+	for i := range list.Items {
+		l := &list.Items[i]
+		// Basic sanity for holder identity
+		if l.Spec.HolderIdentity == nil || *l.Spec.HolderIdentity == "" {
+			continue
+		}
+		id := *l.Spec.HolderIdentity
+
+		// Respect expiry: RenewTime + LeaseDurationSeconds
+		if l.Spec.RenewTime == nil || l.Spec.LeaseDurationSeconds == nil {
+			// If missing, treat as expired/stale.
+			continue
+		}
+		exp := l.Spec.RenewTime.Time.Add(time.Duration(*l.Spec.LeaseDurationSeconds) * time.Second)
+		if now.After(exp) {
+			continue // stale peer
+		}
+
+		// Weight from annotation (optional)
+		weight := defaultWeight
+		if wStr := l.Annotations[annotWeight]; wStr != "" {
+			if w64, err := strconv.ParseUint(wStr, 10, 32); err == nil && w64 > 0 {
+				weight = uint32(w64)
+			}
+		}
+
+		next[id] = sharder.PeerInfo{ID: id, Weight: weight}
+	}
+
+	// Store snapshot (including ourselves; if not listed yet, ensure we're present).
+	next[r.self.ID] = sharder.PeerInfo{ID: r.self.ID, Weight: r.self.Weight}
+
+	r.mu.Lock()
+	r.peers = next
+	r.mu.Unlock()
+	return nil
+}

--- a/pkg/manager/coordinator/sharded/peers/registry_test.go
+++ b/pkg/manager/coordinator/sharded/peers/registry_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package peers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	coordv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	_ "github.com/onsi/ginkgo/v2"
+)
+
+const (
+	testNS  = "kube-system"
+	prefix  = "mcr-peer"
+	selfID  = "peer-0"
+	otherID = "peer-1"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := coordv1.AddToScheme(s); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	return s
+}
+
+func getLease(t *testing.T, c crclient.Client, name string) *coordv1.Lease {
+	t.Helper()
+	var ls coordv1.Lease
+	if err := c.Get(context.Background(), crclient.ObjectKey{Namespace: testNS, Name: name}, &ls); err != nil {
+		t.Fatalf("get lease %s: %v", name, err)
+	}
+	return &ls
+}
+
+func TestRenewSelfLease_CreateThenUpdate(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	r := NewLeaseRegistry(c, testNS, prefix, selfID, 2, logr.Discard()).(*leaseRegistry)
+
+	// First call creates the Lease
+	if err := r.renewSelfLease(context.Background()); err != nil {
+		t.Fatalf("renewSelfLease create: %v", err)
+	}
+	name := prefix + "-" + selfID
+	ls := getLease(t, c, name)
+	if ls.Spec.HolderIdentity == nil || *ls.Spec.HolderIdentity != selfID {
+		t.Fatalf("holder = %v, want %q", ls.Spec.HolderIdentity, selfID)
+	}
+	if got := ls.Labels[labelPeer]; got != "true" {
+		t.Fatalf("label %s = %q, want true", labelPeer, got)
+	}
+	if got := ls.Labels[labelPrefix]; got != prefix {
+		t.Fatalf("label %s = %q, want %s", labelPrefix, got, prefix)
+	}
+	if got := ls.Annotations[annotWeight]; got != "2" {
+		t.Fatalf("weight annot = %q, want 2", got)
+	}
+
+	// Update path: change weight and ensure it is written
+	r.self.Weight = 3
+	time.Sleep(1 * time.Millisecond) // ensure RenewTime advances
+	if err := r.renewSelfLease(context.Background()); err != nil {
+		t.Fatalf("renewSelfLease update: %v", err)
+	}
+	ls2 := getLease(t, c, name)
+	if got := ls2.Annotations[annotWeight]; got != "3" {
+		t.Fatalf("updated weight annot = %q, want 3", got)
+	}
+	if ls.Spec.RenewTime == nil || ls2.Spec.RenewTime == nil ||
+		!ls2.Spec.RenewTime.Time.After(ls.Spec.RenewTime.Time) {
+		t.Fatalf("RenewTime did not advance: old=%v new=%v", ls.Spec.RenewTime, ls2.Spec.RenewTime)
+	}
+}
+
+func TestRefreshPeers_FiltersAndParses(t *testing.T) {
+	s := newScheme(t)
+
+	now := time.Now()
+	validRenew := metav1.NewMicroTime(now)
+	expiredRenew := metav1.NewMicroTime(now.Add(-time.Hour))
+	dur := int32(60)
+
+	// valid peer (otherID), correct labels/prefix, not expired, weight 5
+	valid := &coordv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS, Name: prefix + "-" + otherID,
+			Labels: map[string]string{
+				labelPartOf: partOfValue,
+				labelPeer:   "true",
+				labelPrefix: prefix,
+			},
+			Annotations: map[string]string{
+				annotWeight: "5",
+			},
+		},
+		Spec: coordv1.LeaseSpec{
+			HolderIdentity:       &[]string{otherID}[0],
+			RenewTime:            &validRenew,
+			LeaseDurationSeconds: &dur,
+		},
+	}
+
+	// expired peer (should be ignored)
+	expired := &coordv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS, Name: prefix + "-expired",
+			Labels: map[string]string{
+				labelPeer:   "true",
+				labelPrefix: prefix,
+			},
+		},
+		Spec: coordv1.LeaseSpec{
+			HolderIdentity:       &[]string{"nobody"}[0],
+			RenewTime:            &expiredRenew,
+			LeaseDurationSeconds: &dur,
+		},
+	}
+
+	// wrong prefix (should be ignored)
+	wrong := &coordv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS, Name: "otherprefix-" + "x",
+			Labels: map[string]string{
+				labelPeer:   "true",
+				labelPrefix: "otherprefix",
+			},
+		},
+		Spec: coordv1.LeaseSpec{
+			HolderIdentity:       &[]string{"x"}[0],
+			RenewTime:            &validRenew,
+			LeaseDurationSeconds: &dur,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(valid, expired, wrong).Build()
+
+	r := NewLeaseRegistry(c, testNS, prefix, selfID, 1, logr.Discard()).(*leaseRegistry)
+	if err := r.refreshPeers(context.Background()); err != nil {
+		t.Fatalf("refreshPeers: %v", err)
+	}
+
+	snap := r.Snapshot()
+
+	// Expect self + valid other
+	want := map[string]uint32{
+		selfID:  1,
+		otherID: 5,
+	}
+	got := map[string]uint32{}
+	for _, p := range snap {
+		got[p.ID] = p.Weight
+	}
+	for id, w := range want {
+		if got[id] != w {
+			t.Fatalf("snapshot missing/mismatch for %s: got %d want %d; full=%v", id, got[id], w, got)
+		}
+	}
+	// Should not include expired/wrong
+	if _, ok := got["expired"]; ok {
+		t.Fatalf("snapshot unexpectedly contains expired")
+	}
+	if _, ok := got["x"]; ok {
+		t.Fatalf("snapshot unexpectedly contains wrong prefix")
+	}
+}
+
+func TestRun_PublishesSelfAndStopsOnCancel(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	r := NewLeaseRegistry(c, testNS, prefix, selfID, 1, logr.Discard()).(*leaseRegistry)
+
+	// Speed up the loop for the test
+	r.ttl = 2 * time.Second
+	r.renew = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		_ = r.Run(ctx)
+		close(done)
+	}()
+
+	// wait for at least one tick
+	time.Sleep(120 * time.Millisecond)
+
+	// self lease should exist
+	name := prefix + "-" + selfID
+	_ = getLease(t, c, name) // will fatal if missing
+
+	// cancel and ensure Run returns
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Run did not exit after cancel")
+	}
+}

--- a/pkg/manager/coordinator/sharded/sharder/hrw.go
+++ b/pkg/manager/coordinator/sharded/sharder/hrw.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharder
+
+import (
+	"hash/fnv"
+)
+
+// HRW implements Highest-Random-Weight (aka Rendezvous) hashing.
+//
+// Given a stable cluster identifier and a snapshot of peers, HRW selects
+// the peer with the highest score for that cluster. All peers compute the
+// same scores independently, so the winner is deterministic as long as
+// the inputs (clusterID, peer IDs, weights) are identical.
+//
+// Weighting: this implementation biases selection by multiplying the
+// score with the peer's Weight (0 is treated as 1). This is a simple and
+// fast heuristic; if you need proportional weighting with stronger
+// distribution guarantees, consider the canonical weighted rendezvous
+// formula (e.g., score = -ln(u)/w).
+type HRW struct{}
+
+// NewHRW returns a new HRW sharder.
+func NewHRW() *HRW { return &HRW{} }
+
+// ShouldOwn returns true if self is the HRW winner for clusterID among peers.
+//
+// Inputs:
+//   - clusterID: a stable string that identifies the shard/cluster (e.g., namespace name).
+//   - peers:     the full membership snapshot used for the decision; all participants
+//     should use the same list (order does not matter).
+//   - self:      the caller's peer info.
+//
+// Behavior & caveats:
+//   - If peers is empty, this returns true (caller may choose to gate with fencing).
+//   - Weight 0 is treated as 1 (no special meaning).
+//   - Ties are broken by "last wins" in the iteration order (practically
+//     unreachable with 64-bit hashing, but documented for completeness).
+//   - The hash (FNV-1a, 64-bit) is fast and stable but not cryptographically secure.
+//   - This method does not enforce ownership; callers should still use a
+//     per-shard fence (e.g., a Lease) to serialize actual work.
+//
+// Determinism requirements:
+//   - All peers must see the same peer IDs and weights when computing.
+//   - clusterID must be stable across processes (same input → same winner).
+func (h *HRW) ShouldOwn(clusterID string, peers []PeerInfo, self PeerInfo) bool {
+	if len(peers) == 0 {
+		return true
+	}
+	var best PeerInfo
+	var bestScore uint64
+	for _, p := range peers {
+		score := hash64(clusterID + "|" + p.ID)
+		if p.Weight == 0 {
+			p.Weight = 1
+		}
+		score *= uint64(p.Weight)
+		if score >= bestScore {
+			bestScore = score
+			best = p
+		}
+	}
+	return best.ID == self.ID
+}
+
+// hash64 returns a stable 64-bit FNV-1a hash of s.
+// Fast, non-cryptographic; suitable for rendezvous hashing.
+func hash64(s string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum64()
+}

--- a/pkg/manager/coordinator/sharded/sharder/sharder.go
+++ b/pkg/manager/coordinator/sharded/sharder/sharder.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharder
+
+// PeerInfo describes a participating peer in sharding decisions.
+//
+// ID must be a stable, unique identifier for the peer (e.g., pod hostname).
+//
+// Weight is a relative capacity hint. The current HRW implementation in this
+// package treats 0 as 1 and multiplies the peer’s score by Weight. With many
+// shards, a peer’s expected share of ownership is roughly proportional to
+// Weight relative to the sum of all peers’ weights. If you need stricter,
+// provably proportional weighting, use a canonical weighted rendezvous score
+// (e.g., s = -ln(u)/w) instead of simple multiplication.
+type PeerInfo struct {
+	ID     string
+	Weight uint32 // optional (default 1)
+}
+
+// Sharder chooses whether the local peer should "own" (run) a given cluster.
+//
+// Implementations must be deterministic across peers given the same inputs.
+// ShouldOwn does not enforce ownership; callers should still gate actual work
+// behind a per-cluster fence (e.g., a Lease) to guarantee single-writer.
+type Sharder interface {
+	// ShouldOwn returns true if self is the winner for clusterID among peers.
+	// - clusterID: stable identifier for the shard
+	// - peers: full membership snapshot (order-independent)
+	// - self:  the caller’s PeerInfo
+	ShouldOwn(clusterID string, peers []PeerInfo, self PeerInfo) bool
+}

--- a/pkg/manager/coordinator/sharded/sharding_test.go
+++ b/pkg/manager/coordinator/sharded/sharding_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharded
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded/sharder"
+)
+
+type fakeRegistry struct{ p sharder.PeerInfo }
+
+func (f *fakeRegistry) Self() sharder.PeerInfo        { return f.p }
+func (f *fakeRegistry) Snapshot() []sharder.PeerInfo  { return []sharder.PeerInfo{f.p} }
+func (f *fakeRegistry) Run(ctx context.Context) error { <-ctx.Done(); return ctx.Err() }
+
+func TestOptions_ApplyPeerRegistry(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = coordinationv1.AddToScheme(s)
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	reg := &fakeRegistry{p: sharder.PeerInfo{ID: "x", Weight: 7}}
+	c := New(cli, logr.Discard())
+
+	WithPeerRegistry(reg)(c)
+	if c.peers != reg {
+		t.Fatalf("expected custom registry applied")
+	}
+	if c.self != reg.Self() {
+		t.Fatalf("expected self to be updated from registry")
+	}
+}
+
+func TestOptions_ApplyLeaseAndTimings(t *testing.T) {
+	c := New(nil, logr.Discard())
+
+	WithShardLease("ns", "name")(c)
+	WithPerClusterLease(true)(c)
+	WithLeaseTimings(30*time.Second, 10*time.Second, 750*time.Millisecond)(c)
+	WithSynchronizationIntervals(5*time.Second, 15*time.Second)(c)
+
+	cfg := c.cfg
+	if cfg.FenceNS != "ns" || cfg.FencePrefix != "name" || !cfg.PerClusterLease {
+		t.Fatalf("lease cfg not applied: %+v", cfg)
+	}
+	if cfg.LeaseDuration != 30*time.Second || cfg.LeaseRenew != 10*time.Second || cfg.FenceThrottle != 750*time.Millisecond {
+		t.Fatalf("timings not applied: %+v", cfg)
+	}
+	if cfg.Probe != 5*time.Second || cfg.Rehash != 15*time.Second {
+		t.Fatalf("cadence not applied: %+v", cfg)
+	}
+}

--- a/pkg/manager/coordinator/sharded/synchronization_envtest_test.go
+++ b/pkg/manager/coordinator/sharded/synchronization_envtest_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharded_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded"
+	"sigs.k8s.io/multicluster-runtime/providers/namespace"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Sharded coordinator envtest (namespace provider)", func() {
+	It("distributes leases and reconciles per-namespace", func(ctx SpecContext) {
+		// Build a direct client (no cache) for setup/reads
+		sch := runtime.NewScheme()
+		Expect(corev1.AddToScheme(sch)).To(Succeed())
+		Expect(coordinationv1.AddToScheme(sch)).To(Succeed())
+		directCli, err := client.New(cfg, client.Options{Scheme: sch})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Ensure kube-system exists for fencing leases
+		{
+			var ks corev1.Namespace
+			err := directCli.Get(ctx, client.ObjectKey{Name: "kube-system"}, &ks)
+			if apierrors.IsNotFound(err) {
+				Expect(directCli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}})).To(Succeed())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+
+		// Create N namespaces to act as clusters
+		nsNames := []string{"zoo", "jungle", "island"}
+		for _, n := range nsNames {
+			Expect(directCli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: n}})).To(Succeed())
+		}
+
+		// Provider: namespaces as clusters (uses its own cache via cluster)
+		host, err := cluster.New(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		prov := namespace.New(host)
+
+		// Build mc manager with short timings
+		m, err := mcmanager.New(cfg, prov, manager.Options{},
+			mcmanager.WithCoordinator(
+				sharded.New(directCli, logr.Discard(),
+					sharded.WithShardLease("kube-system", "mcr-shard"),
+					sharded.WithPerClusterLease(true),
+					sharded.WithLeaseTimings(6*time.Second, 2*time.Second, 100*time.Millisecond),
+					sharded.WithSynchronizationIntervals(200*time.Millisecond, 1*time.Second),
+				),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Add a trivial runnable to exercise engagement
+		r := &noopRunnable{}
+		Expect(m.Add(r)).To(Succeed())
+
+		cctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// Start manager and provider
+		go func() { _ = host.Start(cctx) }()
+		go func() { _ = m.Start(cctx) }()
+
+		// Eventually expect three leases with holders set (read via direct client)
+		Eventually(func(g Gomega) {
+			for _, n := range nsNames {
+				var ls coordinationv1.Lease
+				key := client.ObjectKey{Namespace: "kube-system", Name: fmt.Sprintf("mcr-shard-%s", n)}
+				g.Expect(directCli.Get(ctx, key, &ls)).To(Succeed())
+				g.Expect(ls.Spec.HolderIdentity).NotTo(BeNil())
+				g.Expect(*ls.Spec.HolderIdentity).NotTo(BeEmpty())
+			}
+		}).WithTimeout(20 * time.Second).WithPolling(200 * time.Millisecond).Should(Succeed())
+	})
+})
+
+type noopRunnable struct{}
+
+func (n *noopRunnable) Start(ctx context.Context) error                                   { <-ctx.Done(); return ctx.Err() }
+func (n *noopRunnable) Engage(ctx context.Context, name string, cl cluster.Cluster) error { return nil }

--- a/pkg/manager/coordinator/sharded/synchronization_test.go
+++ b/pkg/manager/coordinator/sharded/synchronization_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharded
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/manager/coordinator/sharded/sharder"
+)
+
+type stubSharder struct{ own bool }
+
+func (s *stubSharder) ShouldOwn(clusterID string, _ []sharder.PeerInfo, _ sharder.PeerInfo) bool {
+	return s.own
+}
+
+type stubRegistry struct{ self sharder.PeerInfo }
+
+func (r *stubRegistry) Self() sharder.PeerInfo        { return r.self }
+func (r *stubRegistry) Snapshot() []sharder.PeerInfo  { return []sharder.PeerInfo{r.self} }
+func (r *stubRegistry) Run(ctx context.Context) error { <-ctx.Done(); return ctx.Err() }
+
+type stubRunnable struct{ called chan string }
+
+func (s *stubRunnable) Engage(ctx context.Context, name string, cl cluster.Cluster) error {
+	select {
+	case s.called <- name:
+	default:
+	}
+	return nil
+}
+
+func TestCoordinator_StartsWhenShouldOwnAndFenceAcquired(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := coordinationv1.AddToScheme(s); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	cfg := Config{
+		FenceNS: "kube-system", FencePrefix: "mcr-shard", PerClusterLease: true,
+		LeaseDuration: 3 * time.Second, LeaseRenew: 50 * time.Millisecond, FenceThrottle: 50 * time.Millisecond,
+		PeerPrefix: "mcr-peer", PeerWeight: 1, Probe: 10 * time.Millisecond,
+	}
+	reg := &stubRegistry{self: sharder.PeerInfo{ID: "peer-0", Weight: 1}}
+	sh := &stubSharder{own: true}
+	c := New(cli, logr.Discard(),
+		withConfig(cfg),
+		WithPeerRegistry(reg),
+		WithSharder(sh),
+	)
+
+	sink := &stubRunnable{called: make(chan string, 1)}
+	c.AddRunnable(sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := c.Engage(ctx, "zoo", nil); err != nil {
+		t.Fatalf("engage: %v", err)
+	}
+	// Force a recompute to decide and start
+	c.recompute(ctx)
+
+	select {
+	case name := <-sink.called:
+		if name != "zoo" {
+			t.Fatalf("expected engage for zoo, got %s", name)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected runnable to be engaged")
+	}
+
+	// Verify Lease created and held by self
+	var ls coordinationv1.Lease
+	key := client.ObjectKey{Namespace: cfg.FenceNS, Name: c.fenceName("zoo")}
+	if err := cli.Get(ctx, key, &ls); err != nil {
+		t.Fatalf("get lease: %v", err)
+	}
+	if ls.Spec.HolderIdentity == nil || *ls.Spec.HolderIdentity != reg.self.ID {
+		t.Fatalf("expected holder %q, got %+v", reg.self.ID, ls.Spec.HolderIdentity)
+	}
+}
+
+func TestCoordinator_StopsAndReleasesWhenShouldOwnFalse(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := coordinationv1.AddToScheme(s); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	cfg := Config{
+		FenceNS: "kube-system", FencePrefix: "mcr-shard", PerClusterLease: true,
+		LeaseDuration: 3 * time.Second, LeaseRenew: 50 * time.Millisecond, FenceThrottle: 50 * time.Millisecond,
+		PeerPrefix: "mcr-peer", PeerWeight: 1, Probe: 10 * time.Millisecond,
+	}
+	reg := &stubRegistry{self: sharder.PeerInfo{ID: "peer-0", Weight: 1}}
+	sh := &stubSharder{own: true}
+	c := New(cli, logr.Discard(),
+		withConfig(cfg),
+		WithPeerRegistry(reg),
+		WithSharder(sh),
+	)
+
+	c.AddRunnable(&stubRunnable{called: make(chan string, 1)})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := c.Engage(ctx, "zoo", nil); err != nil {
+		t.Fatalf("engage: %v", err)
+	}
+	// start and acquire lease
+	c.recompute(ctx)
+
+	// Flip ownership to false and recompute; coordinator should stop and release fence
+	sh.own = false
+	c.recompute(ctx)
+
+	// Poll for lease holder cleared by Release()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var ls coordinationv1.Lease
+		if err := cli.Get(ctx, client.ObjectKey{Namespace: cfg.FenceNS, Name: c.fenceName("zoo")}, &ls); err == nil {
+			if ls.Spec.HolderIdentity != nil && *ls.Spec.HolderIdentity == "" {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected lease holder to be cleared after release")
+}

--- a/pkg/util/sanitize/sanitize.go
+++ b/pkg/util/sanitize/sanitize.go
@@ -1,0 +1,37 @@
+package sanitize
+
+// DNS1123 converts s to a DNS-1123 subdomain-compatible string for resource names.
+// It lowercases, replaces unsupported characters with '-', and trims leading/trailing non-alphanumerics.
+func DNS1123(s string) string {
+	b := make([]rune, 0, len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b = append(b, r+('a'-'A'))
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.':
+			b = append(b, r)
+		default:
+			b = append(b, '-')
+		}
+	}
+	// trim leading/trailing non-alphanumeric
+	start, end := 0, len(b)
+	for start < end {
+		r := b[start]
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			break
+		}
+		start++
+	}
+	for end > start {
+		r := b[end-1]
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			break
+		}
+		end--
+	}
+	if start >= end {
+		return "unknown"
+	}
+	return string(b[start:end])
+}


### PR DESCRIPTION
**What**

Deterministic sharding via HRW (rendezvous) over live peers.
Peer leases mcr-peer-* (membership/weights) + shard leases mcr-shard- (per-cluster fencing, single writer).
Clean handoff: watches detach/re-attach on ownership change.
Rebalance on scale up/down.

**Why**

Prevent double reconciles & cold-start stampede.
Balanced, deterministic ownership with fast failover.

**How to try**

Follow the README (examples/sharded-namespace) for build/deploy/observe steps.

**Changes**

Manager: HRW + per-cluster Lease fencing, peer/fence prefix split.
Controller: per-cluster engagement context, re-engage fix.
Source: removable handler, re-register on new ctx.