### PR TITLE
🌱 Add a workflow to label issues

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,19 @@
+---
+name: Label issues
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: sig/multicluster


### PR DESCRIPTION
This ensures new and reopened issues are labeled sig/multicluster, which makes them show up in our triage filter.

Labels could also be added using issue templates, but users can always choose to create an issue using a blank template and thereby skip the automatic labeling. Using a workflow ensures all issues are caught.