### PR TITLE
:seedling: Use Go 1.24.9 for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ROOT_DIR=$(abspath .)
 #
 # Go.
 #
-GO_VERSION ?= 1.24.2
+GO_VERSION ?= 1.24.9
 
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Small maintenance bump so this repository uses the latest Go release of the 1.24.x series.