### PR TITLE
:sparkles: Add `Options` to `kind` provider for improved configurability

### DIFF
--- a/examples/kind/main.go
+++ b/examples/kind/main.go
@@ -41,7 +41,7 @@ func main() {
 	entryLog := ctrllog.Log.WithName("entrypoint")
 	ctx := signals.SetupSignalHandler()
 
-	provider := kind.New()
+	provider := kind.New(kind.Options{Prefix: "fleet-"})
 	mgr, err := mcmanager.New(ctrl.GetConfigOrDie(), provider, mcmanager.Options{})
 	if err != nil {
 		entryLog.Error(err, "unable to create manager")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This adds `kind.Options` similar to other providers in this repository (e.g. the `kubeconfig` one) which allows configuring options for clusters. One of the use cases would be passing a custom scheme. I threw in a `Prefix` configuration option to make the provider a bit more usable for testing controller implementations in e.g. e2e tests and not rely on the `fleet-` hardcoded prefix.
