### PR TITLE
✨ chore: log missing kubeconfig data as warning

### DIFF
--- a/providers/kubeconfig/provider.go
+++ b/providers/kubeconfig/provider.go
@@ -201,7 +201,7 @@ func (p *Provider) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result
 	// Extract and validate kubeconfig data
 	kubeconfigData, ok := secret.Data[p.opts.KubeconfigSecretKey]
 	if !ok || len(kubeconfigData) == 0 {
-		log.Info("Secret does not contain kubeconfig data, skipping", "key", p.opts.KubeconfigSecretKey)
+		log.Error(nil, "Secret does not contain kubeconfig data, skipping", "key", p.opts.KubeconfigSecretKey)
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
I encountered a problem where the `kubeconfig` field hadn't been set, but the failure was too quiet for me to understand what went wrong.

I think error level makes sense, because if I've labeled the Secret to be used but haven't finished setting it up, I've done something wrong.

Since it's a user error instead of controller error, maybe it should be warn instead? But I didn't see a warn level.

Here's what the logs look like:

```
  2025-10-23T09:25:33-04:00     ERROR   kubeconfig-provider     Secret does not contain kubeconfig data, skipping       {"cluster": "invalid-secret", "secret": "testing/invalid-secret", "key": "config"}
  sigs.k8s.io/multicluster-runtime/providers/kubeconfig.(*Provider).Reconcile
        /Users/mcrenshaw/src/multicluster-runtime/providers/kubeconfig/provider.go:204
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
        /Users/mcrenshaw/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/internal/controller/controller.go:216
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
        /Users/mcrenshaw/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/internal/controller/controller.go:461
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
        /Users/mcrenshaw/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/internal/controller/controller.go:421
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
        /Users/mcrenshaw/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/internal/controller/controller.go:296
```