### PR TITLE
 🐛 Fix examples being installed to GOBIN

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -23,6 +23,7 @@ source ${hack_dir}/common.sh
 
 tmp_root=${TMPDIR:-/tmp}
 kb_root_dir=$tmp_root/kubebuilder
+examples_install_dir="${tmp_root}/mcr-examples"
 
 export GOTOOLCHAIN="go$(make go-version)"
 
@@ -33,9 +34,11 @@ ${hack_dir}/verify.sh
 ${hack_dir}/test-all.sh
 
 header_text "confirming examples compile (via go install)"
+mkdir -p "$examples_install_dir"
 for EXAMPLE in $(ls examples); do
-    pushd examples/${EXAMPLE}; go install ${MOD_OPT} .; popd
+    pushd examples/${EXAMPLE}; GOBIN="$examples_install_dir" go install ${MOD_OPT} .; popd
 done
+rm -r "$examples_install_dir"
 
 echo "passed"
 exit 0


### PR DESCRIPTION
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

In my PATH GOBIN takes precedence over system-installed tools, so when the examples are installed to GOBIN e.g. `kind` stops working.