### PR TITLE
🐛 Fix builder engage options to merge instead of replace

### DIFF
--- a/pkg/builder/multicluster_options.go
+++ b/pkg/builder/multicluster_options.go
@@ -43,12 +43,26 @@ func WithEngageWithProviderClusters(engage bool) EngageOptions {
 
 // ApplyToFor applies this configuration to the given ForInput options.
 func (w EngageOptions) ApplyToFor(opts *ForInput) {
-	opts.EngageOptions = w
+	if w.engageWithLocalCluster != nil {
+		val := *w.engageWithLocalCluster
+		opts.engageWithLocalCluster = &val
+	}
+	if w.engageWithProviderClusters != nil {
+		val := *w.engageWithProviderClusters
+		opts.engageWithProviderClusters = &val
+	}
 }
 
 // ApplyToOwns applies this configuration to the given OwnsInput options.
 func (w EngageOptions) ApplyToOwns(opts *OwnsInput) {
-	opts.EngageOptions = w
+	if w.engageWithLocalCluster != nil {
+		val := *w.engageWithLocalCluster
+		opts.engageWithLocalCluster = &val
+	}
+	if w.engageWithProviderClusters != nil {
+		val := *w.engageWithProviderClusters
+		opts.engageWithProviderClusters = &val
+	}
 }
 
 // ApplyToWatches applies this configuration to the given WatchesInput options.


### PR DESCRIPTION
## Summary

This PR fixes the `EngageOptions` behavior in `ApplyToFor()` and `ApplyToOwns()` to merge options field-by-field instead of replacing the entire struct. This makes the behavior consistent with `ApplyToWatches()`, which already correctly merges options. See #93 

## Problem

When using the multicluster builder with multiple `EngageOptions`, the last option would overwrite all previous options instead of merging them:

```go
mcbuilder.ControllerManagedBy(mcMgr).
    For(&MyResource{},
        mcbuilder.WithEngageWithLocalCluster(true),
        mcbuilder.WithEngageWithProviderClusters(false),
    ).
    Complete(reconciler)
```

Due to the implementation in `ApplyToFor()` and `ApplyToOwns()`, only `engageWithProviderClusters=false` would be applied, while `engageWithLocalCluster` would remain `nil` and fall back to the default.

This made it impossible to configure hub-and-spoke patterns where you want to watch resources in the local cluster but access remote clusters via `GetCluster()`.

## Solution

Changed `ApplyToFor()` and `ApplyToOwns()` to merge options field-by-field, matching the existing pattern in `ApplyToWatches()`:

```go
func (w EngageOptions) ApplyToFor(opts *ForInput) {
    if w.engageWithLocalCluster != nil {
        local := *w.engageWithLocalCluster
        opts.engageWithLocalCluster = &local
    }
    if w.engageWithProviderClusters != nil {
        provider := *w.engageWithProviderClusters
        opts.engageWithProviderClusters = &provider
    }
}
```

This properly merges each field independently while creating new pointer instances to avoid aliasing issues.

## Testing

Verified that the hub-and-spoke pattern now works correctly by testing with the following configuration:

```go
mcbuilder.ControllerManagedBy(mcMgr).
    For(&XCR{},
        mcbuilder.WithEngageWithLocalCluster(true),
        mcbuilder.WithEngageWithProviderClusters(false),
    ).
    Complete(reconciler)
```

The controller now correctly watches only the local cluster while maintaining access to remote clusters via the manager.