### PR TITLE
:warning: Add DefaultClusterOptions to manager 

### DIFF
--- a/providers/cluster-inventory-api/provider.go
+++ b/providers/cluster-inventory-api/provider.go
@@ -134,6 +134,10 @@ func (p *Provider) SetupWithManager(mgr mcmanager.Manager) error {
 	}
 	p.client = localMgr.GetClient()
 
+	// Inherit manager defaults (scheme, etc.) so remote clusters recognise
+	// the same types as the local manager.
+	p.opts.ClusterOptions = append(mgr.DefaultClusterOptions(), p.opts.ClusterOptions...)
+
 	// Create a controller builder
 	controllerBuilder := builder.ControllerManagedBy(localMgr).
 		For(&clusterinventoryv1alpha1.ClusterProfile{}).

--- a/providers/kubeconfig/provider.go
+++ b/providers/kubeconfig/provider.go
@@ -158,6 +158,10 @@ func (p *Provider) SetupWithManager(ctx context.Context, mgr mcmanager.Manager) 
 		return fmt.Errorf("local manager is nil")
 	}
 
+	// Inherit manager defaults (scheme, etc.) so remote clusters recognise
+	// the same types as the local manager.
+	p.opts.ClusterOptions = append(mgr.DefaultClusterOptions(), p.opts.ClusterOptions...)
+
 	// Setup the controller to watch for secrets containing kubeconfig data
 	err := ctrl.NewControllerManagedBy(localMgr).
 		For(&corev1.Secret{}, builder.WithPredicates(predicate.NewPredicateFuncs(


### PR DESCRIPTION
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This pull request introduces a standardized way for cluster providers to inherit default options (such as the scheme) from the local manager when constructing remote clusters. This ensures consistency in type recognition across clusters and simplifies provider setup. The most important changes are:

### Manager interface and implementation

* Added the `DefaultClusterOptions()` method to the `Manager` interface and implemented it in `mcManager` to return cluster options derived from the local manager, such as its scheme. [[1]](diffhunk://#diff-d500fbd6a2aa620607ca5e2a7c3ac4f1a4c82309d1a549561e92abfcb18f2f0eR113-R118) [[2]](diffhunk://#diff-d500fbd6a2aa620607ca5e2a7c3ac4f1a4c82309d1a549561e92abfcb18f2f0eR224-R233)

### Provider setup improvements

* Updated the `cluster-inventory-api` provider to prepend manager default cluster options to its own options during setup, ensuring remote clusters inherit the local manager's scheme and other defaults.
* Updated the `kubeconfig` provider similarly to prepend manager default cluster options during setup for consistent type recognition in remote clusters.