### PR TITLE
🐛 Fix clusters.Registry.Engage and add clusters.Registry example

### DIFF
--- a/examples/registry/README.md
+++ b/examples/registry/README.md
@@ -1,0 +1,48 @@
+# Registry Example
+
+The [registry](https://pkg.go.dev/sigs.k8s.io/multicluster-runtime@main/pkg/clusters#Registry) is a simple cluster cache.
+
+It can be used as a cluster tracker by adding it to a manager as
+a `Runnable` or as a standalone cluster store to manage sets of
+clusters.
+
+## Example
+
+The example requires a kubeconfig pointing to a running cluster and
+showcases adding the registry as a `Runnable` to a manager.
+
+It uses the namespace provider to yield namespaces in the running
+cluster as clusters to the manager. Every second the clusters known to
+the registry will be printed to stdout:
+
+```text
+current clusters:
+[...]
+current clusters:
+  - default
+  - kube-node-lease
+  - kube-public
+  - kube-system
+  - local-path-storage
+```
+
+Create a namespace in the cluster:
+
+```text
+> kubectl create namespace test
+```
+
+And it will show up in the output when the provider has engaged the manager with the cluster:
+
+```text
+current clusters:
+  [...]
+I0313 00:24:09.447817    5156 provider.go:78] "Encountered namespace" logger="namespaced-cluster-provider" namespace="test"
+current clusters:
+  - default
+  - kube-node-lease
+  - kube-public
+  - kube-system
+  - local-path-storage
+  - test
+```

--- a/examples/registry/main.go
+++ b/examples/registry/main.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"k8s.io/klog/v2"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/clusters"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/providers/namespace"
+)
+
+func init() {
+	ctrl.SetLogger(klog.Background())
+}
+
+func main() {
+	ctx := signals.SetupSignalHandler()
+
+	if err := run(ctx); err != nil {
+		log.Fatalf("failed to run controller: %v", err)
+	}
+}
+
+func run(ctx context.Context) error {
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	cl, err := cluster.New(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create cluster: %w", err)
+	}
+	provider := namespace.New(cl)
+
+	mgr, err := mcmanager.New(cfg, provider, mcmanager.Options{})
+	if err != nil {
+		return fmt.Errorf("unable to set up overall controller manager: %w", err)
+	}
+	registry := clusters.NewRegistry[cluster.Cluster]()
+	if err := mgr.Add(registry); err != nil {
+		return fmt.Errorf("error adding registry as runnable to manager: %w", err)
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return ignoreCanceled(cl.Start(ctx))
+	})
+	g.Go(func() error {
+		return ignoreCanceled(mgr.Start(ctx))
+	})
+	g.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				fmt.Println("current clusters:")
+				for _, clusterName := range registry.ClusterNames() {
+					fmt.Printf("  - %s\n", clusterName)
+				}
+				time.Sleep(1 * time.Second)
+			}
+		}
+	})
+	return g.Wait()
+}
+
+func ignoreCanceled(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}

--- a/pkg/clusters/registry.go
+++ b/pkg/clusters/registry.go
@@ -63,7 +63,14 @@ func (r *Registry[T]) Start(ctx context.Context) error {
 
 // Engage adds or replaces the cluster with the given name in the registry.
 func (r *Registry[T]) Engage(ctx context.Context, name multicluster.ClusterName, cl cluster.Cluster) error {
-	return r.AddOrReplace(ctx, name, cl.(T))
+	if err := r.AddOrReplace(ctx, name, cl.(T)); err != nil {
+		return err
+	}
+	go func() {
+		<-ctx.Done()
+		r.RemoveIfEqual(name, cl.(T))
+	}()
+	return nil
 }
 
 // ClusterNames returns the names of all clusters in a sorted order.
@@ -110,6 +117,21 @@ func (r *Registry[T]) Add(ctx context.Context, name multicluster.ClusterName, cl
 func (r *Registry[T]) Remove(name multicluster.ClusterName) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
+	delete(r.clusters, name)
+}
+
+// RemoveIfEqual removes a cluster if the currently stored cluster is
+// equal to the passed cluster.
+func (r *Registry[T]) RemoveIfEqual(name multicluster.ClusterName, cl T) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	stored, ok := r.clusters[name]
+	if !ok {
+		return
+	}
+	if any(cl) != any(stored) {
+		return
+	}
 	delete(r.clusters, name)
 }
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

1. Fixes a bug in clusters.Registry that clusters are not properly removed after their context is cancelled.
2. Adds an example for clusters.Registry as a Runnable, see #142 

The suggestions made by the bot don't make a ton of sense in the context of the registry. I could see a more elaborate example that sorts clusters into different registries depending on the cluster type (e.g. manager, cache worker, db worker) but that holds little teaching value without something practical to do.