### PR TITLE
🐛 Pass manager options to controller

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -64,6 +64,7 @@ func New(name string, mgr mcmanager.Manager, options Options) (Controller, error
 //
 // The name must be unique as it is used to identify the controller in metrics and logs.
 func NewTyped[request mcreconcile.ClusterAware[request]](name string, mgr mcmanager.Manager, options controller.TypedOptions[request]) (TypedController[request], error) {
+	options.DefaultFromConfig(mgr.GetControllerOptions())
 	c, err := NewTypedUnmanaged(name, mgr, options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
NewTyped did not apply the manager's controller options to the controller's TypedOptions, so settings configured on the manager (e.g. MaxConcurrentReconciles) were silently dropped. Default the options from the manager's controller config before constructing the controller so manager-level configuration is honored.
