### PR TITLE
🐛 lower minimum required go version to 1.26.0

### DIFF
--- a/examples/cluster-api/go.mod
+++ b/examples/cluster-api/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/examples/cluster-api
 
-go 1.26.3
+go 1.26.0
 
 replace (
 	sigs.k8s.io/multicluster-runtime => ../..

--- a/examples/cluster-inventory-api/go.mod
+++ b/examples/cluster-inventory-api/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/examples/cluster-inventory-api
 
-go 1.26.3
+go 1.26.0
 
 replace (
 	sigs.k8s.io/multicluster-runtime => ../..

--- a/examples/file/go.mod
+++ b/examples/file/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/examples/file
 
-go 1.26.3
+go 1.26.0
 
 replace (
 	sigs.k8s.io/multicluster-runtime => ../..

--- a/examples/kind/go.mod
+++ b/examples/kind/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/examples/kind
 
-go 1.26.3
+go 1.26.0
 
 replace (
 	sigs.k8s.io/multicluster-runtime => ../..

--- a/examples/kubeconfig/go.mod
+++ b/examples/kubeconfig/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/examples/kubeconfig
 
-go 1.26.3
+go 1.26.0
 
 replace (
 	sigs.k8s.io/multicluster-runtime => ../..

--- a/examples/sync-local-to-remote/go.mod
+++ b/examples/sync-local-to-remote/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/examples/local-to-uniform
 
-go 1.26.3
+go 1.26.0
 
 replace (
 	sigs.k8s.io/multicluster-runtime => ../..

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime
 
-go 1.26.3
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/providers/cluster-api/go.mod
+++ b/providers/cluster-api/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/providers/cluster-api
 
-go 1.26.3
+go 1.26.0
 
 replace sigs.k8s.io/multicluster-runtime => ../..
 

--- a/providers/cluster-inventory-api/go.mod
+++ b/providers/cluster-inventory-api/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/providers/cluster-inventory-api
 
-go 1.26.3
+go 1.26.0
 
 replace sigs.k8s.io/multicluster-runtime => ../..
 

--- a/providers/file/go.mod
+++ b/providers/file/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/providers/file
 
-go 1.26.3
+go 1.26.0
 
 replace sigs.k8s.io/multicluster-runtime => ../..
 

--- a/providers/kind/go.mod
+++ b/providers/kind/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/multicluster-runtime/providers/kind
 
-go 1.26.3
+go 1.26.0
 
 replace sigs.k8s.io/multicluster-runtime => ../..
 


### PR DESCRIPTION
multicluster-runtime builds just fine with Go 1.26.0. There is no reason to artificially inflate the version and constantly needlessly bump the `go` directive in all go.mod files in this repo. It just causes unnecessary churn for downstream consumers.

(Yes, I am beginning to consider it a mistake by the Go team to even accept patch versions for the `go` directive.)