### PR TITLE
✨ feat: add predicates to capi provider

### DIFF
--- a/providers/cluster-api/provider.go
+++ b/providers/cluster-api/provider.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -72,6 +73,12 @@ type Options struct {
 	// If not provided, defaults to checking that the Cluster's control plane has
 	// been initialized.
 	IsReady func(ctx context.Context, ccl client.Object) bool
+
+	// Predicates are controller-runtime predicates applied to the Cluster watch.
+	// Only Cluster objects passing all predicates will be reconciled by this provider.
+	// Use this to filter by infrastructure kind, labels, or any other object field
+	// so that non-matching clusters are never processed.
+	Predicates []predicate.Predicate
 }
 
 func setDefaults(opts *Options) {
@@ -152,7 +159,7 @@ func (p *Provider) SetupWithManager(mgr mcmanager.Manager) error {
 	p.client = localMgr.GetClient()
 
 	if err := builder.ControllerManagedBy(localMgr).
-		For(p.opts.ObjectToWatch).
+		For(p.opts.ObjectToWatch, builder.WithPredicates(p.opts.Predicates...)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). // no parallelism.
 		Complete(p); err != nil {
 		return fmt.Errorf("failed to create controller: %w", err)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

# What does this do?

Adds a `Predicates []predicate.Predicate` field to `capi.Options` and forwards it to the `builder.For()` call in `SetupWithManager`, so consumers can attach standard controller-runtime predicates to the CAPI Cluster watch. Without this the provider reconciles every Cluster object on the management cluster unconditionally so there is no way to skip non-matching clusters before Reconcile runs. 

# Why do we need it?

This matters when the management cluster hosts CAPI Cluster objects for multiple infrastructure providers (e.g. GCP, OpenStack). Consumers that only handle one provider type had no hook to prevent the provider from calling Engage on irrelevant clusters.