### PR TITLE
:bug: Gate cluster ownership at GetCluster and reconcile dispatch

### DIFF
--- a/pkg/builder/forked_controller.go
+++ b/pkg/builder/forked_controller.go
@@ -76,6 +76,7 @@ type TypedBuilder[request mcreconcile.ClusterAware[request]] struct {
 	newController    func(name string, mgr mcmanager.Manager, options controller.TypedOptions[request]) (mccontroller.TypedController[request], error)
 
 	enableClusterNotFoundWrapper *bool
+	enableOwnershipWrapper       *bool
 }
 
 // ControllerManagedBy returns a new controller builder that will be started by the provided Manager.
@@ -270,6 +271,20 @@ func (blder *TypedBuilder[request]) WithLogConstructor(logConstructor func(*requ
 // and can be disabled with this builder method by setting it to false.
 func (blder *TypedBuilder[request]) WithClusterNotFoundWrapper(enabled bool) *TypedBuilder[request] {
 	blder.enableClusterNotFoundWrapper = ptr.To(enabled)
+	return blder
+}
+
+// WithOwnershipWrapper enables or disables a reconciler that is wrapped around the original
+// reconciler added to this builder. [reconcile.OwnershipWrapper] skips invoking the reconciler
+// for requests whose cluster this process does not currently own, per the Manager's configured
+// Coordinator, returning a successful no-op result instead. This protects reconcilers that
+// reach a cluster through a path other than a coordinator-gated per-cluster watch — for example
+// a raw source registered against a single, fixed cluster via Source.ForCluster, whose events
+// can reference any cluster known to the provider regardless of this process's ownership of it.
+// This wrapper is enabled by default and can be disabled with this builder method by setting it
+// to false.
+func (blder *TypedBuilder[request]) WithOwnershipWrapper(enabled bool) *TypedBuilder[request] {
+	blder.enableOwnershipWrapper = ptr.To(enabled)
 	return blder
 }
 
@@ -472,6 +487,13 @@ func (blder *TypedBuilder[request]) doController(r reconcile.TypedReconciler[req
 	// the ClusterNotFound wrapper is enabled by default, but can be disabled with WithClusterNotFoundWrapper(false).
 	if ptr.Deref(blder.enableClusterNotFoundWrapper, true) {
 		ctrlOptions.Reconciler = mcreconcile.NewClusterNotFoundWrapper(ctrlOptions.Reconciler)
+	}
+
+	// the ownership wrapper is enabled by default, but can be disabled with WithOwnershipWrapper(false).
+	// It runs outermost so a request for a cluster this process doesn't own is skipped before any
+	// other reconcile logic (including the ClusterNotFound wrapper above) runs.
+	if ptr.Deref(blder.enableOwnershipWrapper, true) {
+		ctrlOptions.Reconciler = mcreconcile.NewOwnershipWrapper(ctrlOptions.Reconciler, blder.mgr)
 	}
 
 	// Retrieve the GVK from the object we're reconciling

--- a/pkg/manager/coordinator.go
+++ b/pkg/manager/coordinator.go
@@ -44,6 +44,14 @@ type Coordinator interface {
 	// (e.g., membership refresh, fencing). Return nil if no background work
 	// is needed.
 	Runnable() manager.Runnable
+
+	// Owns reports whether this process currently owns (has fully started
+	// runnables for) the named cluster. Callers that obtain a cluster
+	// connection through means other than an Engage callback (e.g. Manager.
+	// GetCluster) should consult this before reading or writing that
+	// cluster's resources, since a cluster being reachable does not imply
+	// this process was granted ownership of it.
+	Owns(name multicluster.ClusterName) bool
 }
 
 // WithCoordinator sets a custom Coordinator. EXPERIMENTAL: not a stable API.

--- a/pkg/manager/coordinator/basic/basic.go
+++ b/pkg/manager/coordinator/basic/basic.go
@@ -59,3 +59,8 @@ func (c *Coordinator) Engage(ctx context.Context, name multicluster.ClusterName,
 
 // Runnable returns nil because the basic coordinator has no background work.
 func (c *Coordinator) Runnable() manager.Runnable { return nil }
+
+// Owns always returns true: the basic coordinator engages every cluster
+// unconditionally, so every cluster it knows about is "owned" by this
+// process.
+func (c *Coordinator) Owns(multicluster.ClusterName) bool { return true }

--- a/pkg/manager/coordinator/sharded/coordinator.go
+++ b/pkg/manager/coordinator/sharded/coordinator.go
@@ -169,6 +169,22 @@ func defaultConfig() Config {
 	}
 }
 
+// Owns reports whether this process currently holds the fence lease and has
+// fully started runnables for the named cluster. Returns false for clusters
+// that are unknown, not yet started, or whose engagement has been stopped
+// (e.g. because a rehash decided another peer should own it, or the fence
+// lease was lost). Callers that obtain a cluster connection through a path
+// other than an Engage callback — such as Manager.GetCluster — must consult
+// this before reading or writing that cluster's resources: the cluster being
+// reachable does not imply this process was granted ownership of it.
+func (c *Coordinator) Owns(name multicluster.ClusterName) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	engm, ok := c.engaged[name]
+	return ok && engm.started
+}
+
 func (c *Coordinator) fenceName(cluster string) string {
 	if c.cfg.PerClusterLease {
 		return fmt.Sprintf("%s-%s", c.cfg.FencePrefix, sanitize.DNS1123(cluster))

--- a/pkg/manager/coordinator/sharded/synchronization_test.go
+++ b/pkg/manager/coordinator/sharded/synchronization_test.go
@@ -108,6 +108,61 @@ func TestCoordinator_StartsWhenShouldOwnAndFenceAcquired(t *testing.T) {
 	}
 }
 
+func TestCoordinator_Owns(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := coordinationv1.AddToScheme(s); err != nil {
+		t.Fatalf("scheme: %v", err)
+	}
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+
+	cfg := Config{
+		FenceNS: "kube-system", FencePrefix: "mcr-shard", PerClusterLease: true,
+		LeaseDuration: 3 * time.Second, LeaseRenew: 50 * time.Millisecond, FenceThrottle: 50 * time.Millisecond,
+		PeerPrefix: "mcr-peer", PeerWeight: 1, Probe: 10 * time.Millisecond,
+	}
+	reg := &stubRegistry{self: sharder.PeerInfo{ID: "peer-0", Weight: 1}}
+	sh := &stubSharder{own: true}
+	c := New(cli, logr.Discard(),
+		withConfig(cfg),
+		WithPeerRegistry(reg),
+		WithSharder(sh),
+	)
+	c.AddAware(&stubRunnable{called: make(chan multicluster.ClusterName, 1)})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if c.Owns("zoo") {
+		t.Fatalf("expected Owns to be false before engagement")
+	}
+
+	if err := c.Engage(ctx, "zoo", nil); err != nil {
+		t.Fatalf("engage: %v", err)
+	}
+
+	if c.Owns("zoo") {
+		t.Fatalf("expected Owns to be false before ownership is decided and the fence acquired")
+	}
+
+	// Force a recompute to decide and start.
+	c.recompute(ctx)
+
+	if !c.Owns("zoo") {
+		t.Fatalf("expected Owns to be true once the fence lease is acquired and runnables started")
+	}
+	if c.Owns("unknown-cluster") {
+		t.Fatalf("expected Owns to be false for a cluster never engaged")
+	}
+
+	// Flip ownership to false and recompute; Owns should reflect the stop.
+	sh.own = false
+	c.recompute(ctx)
+
+	if c.Owns("zoo") {
+		t.Fatalf("expected Owns to be false after losing ownership")
+	}
+}
+
 func TestCoordinator_StopsAndReleasesWhenShouldOwnFalse(t *testing.T) {
 	s := runtime.NewScheme()
 	if err := coordinationv1.AddToScheme(s); err != nil {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -169,16 +169,33 @@ func WithMultiCluster(mgr manager.Manager, provider multicluster.Provider, mcOpt
 	return m, nil
 }
 
+// ErrClusterNotOwned is returned by GetCluster when the named cluster is
+// known to the provider but this process has not been granted ownership of
+// it by the configured Coordinator. See [multicluster.ErrClusterNotOwned].
+var ErrClusterNotOwned = multicluster.ErrClusterNotOwned
+
 // GetCluster returns a cluster for the given identifying cluster name. Get
 // returns an existing cluster if it has been created before.
 // If no cluster is known to the provider under the given cluster name,
 // an error should be returned.
+//
+// If a Coordinator is configured, GetCluster only returns a cluster this
+// process currently owns; it returns ErrClusterNotOwned otherwise. This
+// matters for any watch or event source that is not itself scoped to a
+// single, coordinator-engaged cluster (for example a source registered
+// against a fixed, shared cluster via Source.ForCluster) — such a source can
+// produce reconcile requests naming a cluster this process was never
+// engaged for, and without this check GetCluster would hand back a live,
+// working client for it regardless of ownership.
 func (m *mcManager) GetCluster(ctx context.Context, clusterName multicluster.ClusterName) (cluster.Cluster, error) {
 	if clusterName == LocalCluster {
 		return m.Manager, nil
 	}
 	if m.provider == nil {
 		return nil, fmt.Errorf("no multicluster provider set, but cluster %q passed", clusterName)
+	}
+	if m.coord != nil && !m.coord.Owns(clusterName) {
+		return nil, ErrClusterNotOwned
 	}
 	return m.provider.Get(ctx, clusterName)
 }

--- a/pkg/multicluster/errors.go
+++ b/pkg/multicluster/errors.go
@@ -24,6 +24,17 @@ var (
 	// ErrClusterNotFound can be returned by provider implementations if the cluster requested
 	// doesn't exist and cannot be constructed.
 	ErrClusterNotFound = errClusterNotFound()
+
+	// ErrClusterNotOwned is returned by Manager.GetCluster when the named
+	// cluster is known to the provider but this process has not been
+	// granted ownership of it by the configured Coordinator. Callers should
+	// treat this as a normal, expected condition — not an error worth
+	// logging or retrying aggressively — since another process owns the
+	// cluster and is responsible for it. Ownership may be granted later
+	// (e.g. after a rehash or a lease change).
+	ErrClusterNotOwned = errClusterNotOwned()
 )
 
 func errClusterNotFound() error { return errors.New("cluster not found") }
+
+func errClusterNotOwned() error { return errors.New("cluster is not owned by this process") }

--- a/pkg/reconcile/wrapper.go
+++ b/pkg/reconcile/wrapper.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
@@ -50,5 +51,55 @@ func (r *ClusterNotFoundWrapper[request]) Reconcile(ctx context.Context, req req
 
 // String returns a string representation of the wrapped reconciler.
 func (r *ClusterNotFoundWrapper[request]) String() string {
+	return fmt.Sprintf("%v", r.wrapped)
+}
+
+// clusterGetter is the subset of Manager needed to check cluster ownership.
+// Declared locally (rather than depending on the manager package directly)
+// to avoid an import cycle: pkg/manager already depends on pkg/reconcile.
+// Any Manager satisfies this structurally.
+type clusterGetter interface {
+	GetCluster(ctx context.Context, clusterName multicluster.ClusterName) (cluster.Cluster, error)
+}
+
+// localCluster mirrors manager.LocalCluster: the empty cluster name
+// identifies the local (host) cluster, which is never subject to ownership
+// gating.
+const localCluster = multicluster.ClusterName("")
+
+// OwnershipWrapper wraps an existing [reconcile.TypedReconciler] and skips
+// invoking it for requests whose cluster this process does not currently
+// own, per the Manager's configured Coordinator.
+//
+// This matters beyond what Manager.GetCluster's own ownership check
+// provides: a reconciler that never calls GetCluster (or that does other
+// work before calling it) would otherwise still run for a cluster it was
+// never granted ownership of. It also re-checks ownership on every dequeue,
+// so a request that was queued (or requeued) while this process owned a
+// cluster, but is processed after ownership moved to another peer, is
+// skipped rather than acted on.
+type OwnershipWrapper[request ClusterAware[request]] struct {
+	wrapped reconcile.TypedReconciler[request]
+	mgr     clusterGetter
+}
+
+// NewOwnershipWrapper creates a new [OwnershipWrapper].
+func NewOwnershipWrapper[request ClusterAware[request]](w reconcile.TypedReconciler[request], mgr clusterGetter) reconcile.TypedReconciler[request] {
+	return &OwnershipWrapper[request]{wrapped: w, mgr: mgr}
+}
+
+// Reconcile implements [reconcile.TypedReconciler].
+func (r *OwnershipWrapper[request]) Reconcile(ctx context.Context, req request) (reconcile.Result, error) {
+	if name := req.Cluster(); name != localCluster {
+		if _, err := r.mgr.GetCluster(ctx, name); errors.Is(err, multicluster.ErrClusterNotOwned) {
+			return reconcile.Result{}, nil
+		}
+	}
+
+	return r.wrapped.Reconcile(ctx, req)
+}
+
+// String returns a string representation of the wrapped reconciler.
+func (r *OwnershipWrapper[request]) String() string {
 	return fmt.Sprintf("%v", r.wrapped)
 }

--- a/pkg/reconcile/wrapper_test.go
+++ b/pkg/reconcile/wrapper_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+)
+
+type stubClusterGetter struct {
+	owned map[multicluster.ClusterName]bool
+}
+
+func (g *stubClusterGetter) GetCluster(_ context.Context, name multicluster.ClusterName) (cluster.Cluster, error) {
+	if g.owned[name] {
+		return nil, nil
+	}
+	return nil, multicluster.ErrClusterNotOwned
+}
+
+type countingReconciler struct {
+	calls int
+}
+
+func (r *countingReconciler) Reconcile(context.Context, Request) (reconcile.Result, error) {
+	r.calls++
+	return reconcile.Result{}, nil
+}
+
+func TestOwnershipWrapper_SkipsNonOwnedCluster(t *testing.T) {
+	inner := &countingReconciler{}
+	mgr := &stubClusterGetter{owned: map[multicluster.ClusterName]bool{"owned-cluster": true}}
+	wrapped := NewOwnershipWrapper(inner, mgr)
+
+	req := Request{
+		Request:     reconcile.Request{NamespacedName: types.NamespacedName{Name: "obj"}},
+		ClusterName: "not-owned-cluster",
+	}
+
+	res, err := wrapped.Reconcile(t.Context(), req)
+	if err != nil {
+		t.Fatalf("expected no error for a not-owned cluster, got: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected an empty, non-requeueing result, got: %+v", res)
+	}
+	if inner.calls != 0 {
+		t.Fatalf("expected the wrapped reconciler not to be called, called %d times", inner.calls)
+	}
+}
+
+func TestOwnershipWrapper_CallsThroughForOwnedCluster(t *testing.T) {
+	inner := &countingReconciler{}
+	mgr := &stubClusterGetter{owned: map[multicluster.ClusterName]bool{"owned-cluster": true}}
+	wrapped := NewOwnershipWrapper(inner, mgr)
+
+	req := Request{
+		Request:     reconcile.Request{NamespacedName: types.NamespacedName{Name: "obj"}},
+		ClusterName: "owned-cluster",
+	}
+
+	if _, err := wrapped.Reconcile(t.Context(), req); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if inner.calls != 1 {
+		t.Fatalf("expected the wrapped reconciler to be called once, called %d times", inner.calls)
+	}
+}
+
+func TestOwnershipWrapper_CallsThroughForLocalCluster(t *testing.T) {
+	inner := &countingReconciler{}
+	// No clusters known to the getter at all; the local cluster must still
+	// pass through without ever consulting it.
+	mgr := &stubClusterGetter{}
+	wrapped := NewOwnershipWrapper(inner, mgr)
+
+	req := Request{Request: reconcile.Request{NamespacedName: types.NamespacedName{Name: "obj"}}}
+
+	if _, err := wrapped.Reconcile(t.Context(), req); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if inner.calls != 1 {
+		t.Fatalf("expected the wrapped reconciler to be called once for the local cluster, called %d times", inner.calls)
+	}
+}
+
+func TestOwnershipWrapper_PropagatesOtherErrors(t *testing.T) {
+	boom := errors.New("boom")
+	inner := Func(func(context.Context, Request) (reconcile.Result, error) {
+		return reconcile.Result{}, boom
+	})
+	mgr := &stubClusterGetter{owned: map[multicluster.ClusterName]bool{"owned-cluster": true}}
+	wrapped := NewOwnershipWrapper(inner, mgr)
+
+	req := Request{
+		Request:     reconcile.Request{NamespacedName: types.NamespacedName{Name: "obj"}},
+		ClusterName: "owned-cluster",
+	}
+
+	if _, err := wrapped.Reconcile(t.Context(), req); !errors.Is(err, boom) {
+		t.Fatalf("expected the wrapped reconciler's error to propagate, got: %v", err)
+	}
+}


### PR DESCRIPTION
### Summary

Opened this as a potential solution to #172. This adds a new `Owns` method to the `Coordinator` to determine if a replica own's a given cluster name. The `GetCluster` method and reconcile dispatch were updated to only honor cluster's owned by the `Coordinator`. Replica's that call `GetCluster` for a cluster they don't own will get a new `ErrClusterNotOwned` error. Replica's that enqueue reconcile requests for cluster's they don't own will silently no-op the request.

This behavior can be disabled on a controller by passing `builder.WithOwnershipWrapper(false)`. 

---

Relates to https://github.com/kubernetes-sigs/multicluster-runtime/issues/172