### PR TITLE
🐛  Prevent applying an index twice to a runnable provider [trigger ci]

### DIFF
--- a/providers/multi/provider.go
+++ b/providers/multi/provider.go
@@ -144,6 +144,14 @@ func (p *Provider) startProvider(ctx context.Context, providerName string, aware
 		return
 	}
 
+	p.lock.RLock()
+	for _, indexer := range p.indexers {
+		if err := provider.IndexField(ctx, indexer.Object, indexer.Field, indexer.Extractor); err != nil {
+			p.log.Error(err, "failed to apply indexer to provider", "providerName", providerName, "object", fmt.Sprintf("%T", indexer.Object), "field", indexer.Field)
+		}
+	}
+	p.lock.RUnlock()
+
 	runnable, ok := provider.(multicluster.ProviderRunnable)
 	if !ok {
 		p.log.Info("provider is not runnable, not starting", "providerName", providerName)
@@ -177,14 +185,6 @@ func (p *Provider) startProvider(ctx context.Context, providerName string, aware
 			p.log.Error(err, "error in provider", "providerName", providerName)
 		}
 	}()
-
-	p.lock.RLock()
-	for _, indexer := range p.indexers {
-		if err := provider.IndexField(ctx, indexer.Object, indexer.Field, indexer.Extractor); err != nil {
-			p.log.Error(err, "failed to apply indexer to provider", "providerName", providerName, "object", fmt.Sprintf("%T", indexer.Object), "field", indexer.Field)
-		}
-	}
-	p.lock.RUnlock()
 }
 
 func (p *Provider) splitClusterName(clusterName multicluster.ClusterName) (string, multicluster.ClusterName) {
@@ -287,6 +287,13 @@ func (p *Provider) IndexField(ctx context.Context, obj client.Object, field stri
 		Field:     field,
 		Extractor: extractValue,
 	})
+	// Exit early if the multi provider isn't running.
+	// If it isn't running the indexes are applied to every provider and
+	// then again when the multi provider is started (which starts each
+	// runnable provider).
+	if p.providerNameCh == nil {
+		return nil
+	}
 	var errs error
 	for providerName, provider := range p.providers {
 		if err := provider.IndexField(ctx, obj, field, extractValue); err != nil {

--- a/providers/multi/provider_test.go
+++ b/providers/multi/provider_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
 
@@ -39,6 +40,7 @@ import (
 
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 	nsprovider "sigs.k8s.io/multicluster-runtime/providers/namespace"
 
@@ -57,6 +59,7 @@ var _ = Describe("Provider Multi", Ordered, func() {
 	var cloud1client, cloud2client client.Client
 	var cloud1cluster, cloud2cluster cluster.Cluster
 	var cloud1provider, cloud2provider *nsprovider.Provider
+	var counting *countingProvider
 
 	BeforeAll(func() {
 		By("Setting up the first namespace provider", func() {
@@ -168,6 +171,17 @@ var _ = Describe("Provider Multi", Ordered, func() {
 			runtime.Must(client.IgnoreAlreadyExists(cloud2client.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "island", Name: "selkirk", Labels: map[string]string{"type": "human"}}})))
 		})
 
+		By("Adding a counting provider and an index before starting the manager", func() {
+			counting = &countingProvider{}
+			Expect(provider.AddProvider("counting", counting)).To(Succeed())
+
+			err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.ConfigMap{}, "phase", func(obj client.Object) []string {
+				return []string{obj.GetLabels()["phase"]}
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(counting.indexFieldCalls.Load()).To(BeZero())
+		})
+
 		By("Starting the manager", func() {
 			g.Go(func() error {
 				return ignoreCanceled(mgr.Start(ctx))
@@ -275,6 +289,16 @@ var _ = Describe("Provider Multi", Ordered, func() {
 		Expect(cms.Items[0].Namespace).To(Equal("default"))
 	})
 
+	It("applies each index exactly once to a runnable provider", func() {
+		// One index registered before start, one after: two applications total.
+		Eventually(func() int64 {
+			return counting.indexFieldCalls.Load()
+		}, testTimeout).Should(Equal(int64(2)))
+		Consistently(func() int64 {
+			return counting.indexFieldCalls.Load()
+		}, "1s").Should(Equal(int64(2)))
+	})
+
 	AfterAll(func() {
 		By("Stopping the provider, cluster, manager, and controller", func() {
 			cancel()
@@ -285,6 +309,27 @@ var _ = Describe("Provider Multi", Ordered, func() {
 		})
 	})
 })
+
+var _ multicluster.ProviderRunnable = &countingProvider{}
+
+// countingProvider counts how often IndexField is called.
+type countingProvider struct {
+	indexFieldCalls atomic.Int64
+}
+
+func (c *countingProvider) Get(_ context.Context, _ multicluster.ClusterName) (cluster.Cluster, error) {
+	return nil, multicluster.ErrClusterNotFound
+}
+
+func (c *countingProvider) IndexField(_ context.Context, _ client.Object, _ string, _ client.IndexerFunc) error {
+	c.indexFieldCalls.Add(1)
+	return nil
+}
+
+func (c *countingProvider) Start(ctx context.Context, _ multicluster.Aware) error {
+	<-ctx.Done()
+	return nil
+}
 
 func ignoreCanceled(err error) error {
 	if errors.Is(err, context.Canceled) {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
1. Add a runnable provider to the multi provider before starting the manager
2. Apply an index
3. Start manager

Crashes because the index is applied twice.
This just ensures in .IndexField that indizes are only propagated after the multi provider started.

This is not a problem when adding an index after all providers and manager have been started.
This also wasn't a problem for non-runnable providers since they never got an index twice.

To fix both the index applying is moved up in the `startProvider` and `IndexField` only records the index if it hasn't been started.
The alternative woudl have been tracking which providers were started etcpp.